### PR TITLE
fix: Optional percentile in lightstep SLO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=nobl9.com
 NAMESPACE=nobl9
 NAME=nobl9
 BINARY=terraform-provider-${NAME}
-VERSION=0.1.1
+VERSION=0.1.4
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.1.3"
+      version = "0.1.4"
     }
   }
 }
@@ -27,10 +27,13 @@ provider "nobl9" {
   client_secret = "<CLIENT_SECRET>"
 }
 
+resource "nobl9_project" "test" {
+  name = "test"
+}
+
 resource "nobl9_service" "test" {
-  metadata {
-    name = "test"
-  }
+  name    = "test"
+  project = "test"
 }
 ```
 Documentation

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -412,11 +412,17 @@ func marshalSLOLightstep(s *schema.Set) *n9api.LightstepMetric {
 
 	streamID := metric["stream_id"].(string)
 	typeOfData := metric["type_of_data"].(string)
-	percentile := metric["percentile"].(float64)
+	var percentile *float64
+	if p := metric["percentile"].(float64); p != 0 {
+		// the API does not accept percentile = 0
+		// terraform sets it to 0 even if it was ommitted in the .tf
+		percentile = &p
+	}
+
 	return &n9api.LightstepMetric{
 		StreamID:   &streamID,
 		TypeOfData: &typeOfData,
-		Percentile: &percentile,
+		Percentile: percentile,
 	}
 }
 func marshalSLOSplunkObservability(s *schema.Set) *n9api.SplunkObservabilityMetric {


### PR DESCRIPTION
Lighstep with `type_of_data = latency` cannot contain `percentile`. This PR removes this field from payload to N9 in case it was omitted in .tf.

Sample test tf file:

```terraform
terraform {
  required_providers {
    nobl9 = {
      source = "nobl9.com/nobl9/nobl9"
      version = "0.1.4"
    }
  }
}

provider "nobl9" {
  organization      = "nobl9-dev"
  project           = "test"
  ingest_url        = "*****"
  okta_org_url      = "*****"
  okta_auth_server  = "*****"
  client_id         = "*****"
  client_secret     = "*****"
}

resource "nobl9_project" "test" {
  name = "test"
}

resource "nobl9_service" "test" {
  name    = "test"
  project = "test"
}

resource "nobl9_agent" "test" {
  name      = "test"
  project   = "test"
  source_of = ["Metrics", "Services"]
  agent_type = "lightstep"
  lightstep_config {
    organization = "nobl9-dev"
    project		 = "test"
  }
}

resource "nobl9_slo" "test" {
  name         = "test"
  display_name = "test"
  project      = "test"
  service      = nobl9_service.test.name

  budgeting_method = "Occurrences"

  objective {
    display_name = "obj1"
    target       = 0.7
    value        = 1
    op           = "lt"
  }

  time_window {
    count      = 10
    is_rolling = true
    unit       = "Minute"
  }

  indicator {
    name    = nobl9_agent.test.name
    project = "test"
    kind    = "Agent"
    raw_metric {
      lightstep {
        stream_id = "*****"
        type_of_data = "error_rate"
      }
    }
  }
}
```