### PR TITLE
SRE-738 Alert Method Diff

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,30 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/nobl9/terraform-provider-nobl9/nobl9"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: nobl9.Provider,
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "nobl9.com/nobl9/nobl9", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }

--- a/nobl9/resource_alertmethod_test.go
+++ b/nobl9/resource_alertmethod_test.go
@@ -28,7 +28,7 @@ func TestAcc_Nobl9AlertMethod(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resource.Test(t, resource.TestCase{
+			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:          func() { testAccPreCheck(t) },
 				ProviderFactories: ProviderFactory(),
 				CheckDestroy:      CheckDestory("nobl9_alert_method_"+tc.resourceSuffix, n9api.ObjectAlertMethod),


### PR DESCRIPTION
Alert methods that were not in alphabetical order were showing a diff, since our backend sorts them when returning from the API.  This flattens the array of methods when doing a diff, and compares them, and aborts the diff if theres no difference.

This also adds the option to run the provider in debug mode
