### PR TITLE
fix: Accept attachments in SLO resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.1.4"
+      version = "0.2.1"
     }
   }
 }

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -87,16 +87,8 @@ resource "nobl9_alert_policy" "%s" {
 }
 
 func testAlertPolicyWithIntegration(name string) string {
-	return testWebhookTemplateConfig(name) +
+	return testWebhookTemplateConfig(name+"-am") +
 		fmt.Sprintf(`
-resource "nobl9_alert_method_webhook" "%s-am" {
-  name        = "%s"
-  project     = "%s"
-  description = "wehbook"
-  url         = "http://web.net"
-  template    = "SLO needs attention $slo_name"
-}
-
 resource "nobl9_alert_policy" "%s" {
   name       = "%s"
   project    = "%s"
@@ -124,7 +116,7 @@ resource "nobl9_alert_policy" "%s" {
 	name	= nobl9_alert_method_webhook.%s-am.name
   }
 }
-`, name, name, testProject, name, name, testProject, testProject, name)
+`, name, name, testProject, testProject, name)
 }
 
 func testAlertPolicyWithMultipleIntegration(name string) string {

--- a/nobl9/resource_slo_test.go
+++ b/nobl9/resource_slo_test.go
@@ -25,6 +25,7 @@ func TestAcc_Nobl9SLO(t *testing.T) {
 		{"test-prom-full", testPrometheusSLOFULL},
 		{"test-prom-with-time-slices", testPrometheusSLOWithTimeSlices},
 		{"test-prom-with-raw-metric-in-objective", testPrometheusSLOWithRawMetricInObjective},
+		{"test-prom-with-attachments", testPrometheusWithAttachments},
 		{"test-newrelic", testNewRelicSLO},
 		{"test-appdynamics", testAppdynamicsSLO},
 		{"test-splunk", testSplunkSLO},
@@ -390,6 +391,55 @@ resource "nobl9_slo" ":name" {
     name    = "test-terraform-prom-agent"
     project = ":project"
     kind    = "Agent"
+  }
+}
+`
+	config = strings.ReplaceAll(config, ":name", name)
+	config = strings.ReplaceAll(config, ":project", testProject)
+
+	return config
+}
+
+func testPrometheusWithAttachments(name string) string {
+	config := testService(name+"-service") + `
+resource "nobl9_slo" ":name" {
+  name         = ":name"
+  display_name = ":name"
+  project      = ":project"
+  service      = nobl9_service.:name-service.name
+
+  budgeting_method = "Occurrences"
+
+  objective {
+    display_name = "obj1"
+    target       = 0.7
+    value        = 1
+    op           = "lt"
+    raw_metric {
+      query {
+        prometheus {
+          promql = "1.0"
+        }
+      }
+    }
+  }
+
+  time_window {
+    count      = 10
+    is_rolling = true
+    unit       = "Minute"
+  }
+
+  indicator {
+    name = "test-terraform-prom-agent"
+    project = ":project"
+    kind    = "Agent"
+
+  }
+
+  attachments {
+    display_name = "test"
+    url          = "https://google.com"
   }
 }
 `


### PR DESCRIPTION
N9 API returns `attachments[].displayName` but terraform provider expects `attachments[].display_name`.
This resulted in error `panic: Invalid address to set: []string{"attachments", "0", "displayName"}` when trying to use attachments.

Change was tested against `main` environment:
```
go test ./... -test.run=TestAcc_Nobl9SL
O/test-prom -v -timeout 5m
?   	github.com/nobl9/terraform-provider-nobl9	[no test files]
=== RUN   TestAcc_Nobl9SLO
=== PAUSE TestAcc_Nobl9SLO
=== CONT  TestAcc_Nobl9SLO
=== RUN   TestAcc_Nobl9SLO/test-prometheus
=== RUN   TestAcc_Nobl9SLO/test-prom-with-ap
=== RUN   TestAcc_Nobl9SLO/test-prom-with-countmetrics
=== RUN   TestAcc_Nobl9SLO/test-prom-with-multiple-objectives
=== RUN   TestAcc_Nobl9SLO/test-prom-full
=== RUN   TestAcc_Nobl9SLO/test-prom-with-time-slices
=== RUN   TestAcc_Nobl9SLO/test-prom-with-raw-metric-in-objective
=== RUN   TestAcc_Nobl9SLO/test-prom-with-attachments
--- PASS: TestAcc_Nobl9SLO (39.12s)
    --- PASS: TestAcc_Nobl9SLO/test-prometheus (6.09s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-with-ap (5.37s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-with-countmetrics (4.91s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-with-multiple-objectives (5.19s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-full (4.33s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-with-time-slices (4.94s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-with-raw-metric-in-objective (4.27s)
    --- PASS: TestAcc_Nobl9SLO/test-prom-with-attachments (3.99s)
```