### PR TITLE
fix: Change deprecated GPG build dependency

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,6 +14,7 @@ on:
   push:
     tags:
       - "v*"
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -28,11 +29,10 @@ jobs:
           go-version: 1.17
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses:  crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: setup github
         run: git config --global url."https://n9-machine-user:${{ secrets.GH_TOKEN }}@github.com".insteadOf "https://github.com"
       - name: Run GoReleaser

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=nobl9.com
 NAMESPACE=nobl9
 NAME=nobl9
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.0
+VERSION=0.4.1
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.4.0"
+      version = "0.4.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.4.0"
+      version = "0.4.1"
     }
   }
 }


### PR DESCRIPTION
hashicorp/ghaction-import-gpg@v2.1.0 is now deprecated - we should use crazy-max/ghaction-import-gpg@v5

The issue was spotted during a tag realease - https://github.com/nobl9/terraform-provider-nobl9/runs/7632746572?check_suite_focus=true#step:5:4

I have tested with first:
```
name: release
on:
  push: {}

jobs:
  goreleaser:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v2.4.0
      - name: Unshallow
        run: git fetch --prune --unshallow
      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.17
      - name: Import GPG key
        id: import_gpg
        uses: hashicorp/ghaction-import-gpg@v2.1.0
        env:
          # These secrets will need to be configured for the repository:
          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
          PASSPHRASE: ${{ secrets.PASSPHRASE }}
```

This failed with 
![image](https://user-images.githubusercontent.com/179468/182397299-e3986e0e-1b49-4c02-a5d0-3d711c5d3305.png)

And then updated it with the new GHA:
```
      - name: Import GPG key
        id: import_gpg
        uses: crazy-max/ghaction-import-gpg@v5
        with:
          # These secrets will need to be configured for the repository:
          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
          passphrase: ${{ secrets.PASSPHRASE }}
```

with result:
![image](https://user-images.githubusercontent.com/179468/182397750-ca547367-1bd2-49a7-bd32-5064a39f3123.png)

