### PR TITLE
Bump go-version for goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Import GPG key
         id: import_gpg
         uses:  crazy-max/ghaction-import-gpg@v5

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=nobl9.com
 NAMESPACE=nobl9
 NAME=nobl9
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.1
+VERSION=0.4.2
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 }


### PR DESCRIPTION
Bumping max version of `go-version` to allow `goreleaser` finish its job. 

Failed job: https://github.com/nobl9/terraform-provider-nobl9/runs/7634041747?check_suite_focus=true#step:7:28

![image](https://user-images.githubusercontent.com/56304880/182408525-8ed296c0-d343-4699-9228-679f00b32096.png)
