### PR TITLE
reuse n9 client

### DIFF
--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -2,6 +2,7 @@ package nobl9
 
 import (
 	"context"
+	"sync"
 
 	"github.com/nobl9/nobl9-go"
 
@@ -114,26 +115,33 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 	return config, nil
 }
 
-func newClient(config ProviderConfig, project string) (*nobl9.Client, diag.Diagnostics) {
-	c, err := nobl9.NewClient(
-		config.IngestURL,
-		config.Organization,
-		project,
-		"terraform-"+Version,
-		config.ClientID,
-		config.ClientSecret,
-		config.OktaOrgURL,
-		config.OktaAuthServer,
-	)
-	if err != nil {
+var client *nobl9.Client
+var clientErr error
+var once sync.Once
+
+func getClient(config ProviderConfig, project string) (*nobl9.Client, diag.Diagnostics) {
+
+	once.Do(func() {
+		client, clientErr = nobl9.NewClient(
+			config.IngestURL,
+			config.Organization,
+			project,
+			"terraform-"+Version,
+			config.ClientID,
+			config.ClientSecret,
+			config.OktaOrgURL,
+			config.OktaAuthServer,
+		)
+	})
+	if clientErr != nil {
 		return nil, diag.Diagnostics{
 			diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to create Nobl9 client",
-				Detail:   err.Error(),
+				Detail:   clientErr.Error(),
 			},
 		}
 	}
 
-	return c, nil
+	return client, nil
 }

--- a/nobl9/provider_test.go
+++ b/nobl9/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -80,7 +81,7 @@ func CheckDestory(rsType string, objectType n9api.Object) func(s *terraform.Stat
 		if !ok {
 			return fmt.Errorf("could not cast data to ProviderConfig")
 		}
-		client, ds := newClient(config, testProject)
+		client, ds := getClient(config, testProject)
 		if ds.HasError() {
 			return fmt.Errorf("unable create client when deleting objects")
 		}

--- a/nobl9/resource_agent.go
+++ b/nobl9/resource_agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -93,7 +94,7 @@ func agentSchema() map[string]*schema.Schema {
 
 func resourceAgentApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds != nil {
 		return ds
 	}
@@ -124,7 +125,7 @@ func resourceAgentRead(_ context.Context, d *schema.ResourceData, meta interface
 		// project is empty when importing
 		project = config.Project
 	}
-	client, ds := newClient(config, project)
+	client, ds := getClient(config, project)
 	if ds.HasError() {
 		return ds
 	}
@@ -139,7 +140,7 @@ func resourceAgentRead(_ context.Context, d *schema.ResourceData, meta interface
 
 func resourceAgentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}

--- a/nobl9/resource_alert_policy.go
+++ b/nobl9/resource_alert_policy.go
@@ -256,7 +256,7 @@ func unmarshalAlertMethods(alertMethods []interface{}) interface{} {
 
 func resourceAlertPolicyApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds != nil {
 		return ds
 	}
@@ -286,7 +286,7 @@ func resourceAlertPolicyRead(_ context.Context, d *schema.ResourceData, meta int
 		// project is empty when importing
 		project = config.Project
 	}
-	client, ds := newClient(config, project)
+	client, ds := getClient(config, project)
 	if ds.HasError() {
 		return ds
 	}
@@ -301,7 +301,7 @@ func resourceAlertPolicyRead(_ context.Context, d *schema.ResourceData, meta int
 
 func resourceAlertPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}

--- a/nobl9/resource_alertmethod.go
+++ b/nobl9/resource_alertmethod.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -86,7 +87,7 @@ func (a alertMethod) unmarshalAlertMethod(d *schema.ResourceData, objects []n9ap
 //nolint:lll
 func (a alertMethod) resourceAlertMethodApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds != nil {
 		return ds
 	}
@@ -117,7 +118,7 @@ func (a alertMethod) resourceAlertMethodRead(_ context.Context, d *schema.Resour
 		// project is empty when importing
 		project = config.Project
 	}
-	client, ds := newClient(config, project)
+	client, ds := getClient(config, project)
 	if ds.HasError() {
 		return ds
 	}
@@ -132,7 +133,7 @@ func (a alertMethod) resourceAlertMethodRead(_ context.Context, d *schema.Resour
 
 func resourceAlertMethodDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}

--- a/nobl9/resource_project.go
+++ b/nobl9/resource_project.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -76,7 +77,7 @@ func unmarshalProject(d *schema.ResourceData, objects []n9api.AnyJSONObj) diag.D
 
 func resourceProjectApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, "")
+	client, ds := getClient(config, "")
 	if ds != nil {
 		return ds
 	}
@@ -101,7 +102,7 @@ func resourceProjectApply(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceProjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, "")
+	client, ds := getClient(config, "")
 	if ds.HasError() {
 		return ds
 	}
@@ -116,7 +117,7 @@ func resourceProjectRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 func resourceProjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, "")
+	client, ds := getClient(config, "")
 	if ds.HasError() {
 		return ds
 	}

--- a/nobl9/resource_project_test.go
+++ b/nobl9/resource_project_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -95,7 +96,7 @@ func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) di
 
 func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, wildcardProject)
+	client, ds := getClient(config, wildcardProject)
 	if ds != nil {
 		return ds
 	}
@@ -117,7 +118,7 @@ func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceRoleBindingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, wildcardProject)
+	client, ds := getClient(config, wildcardProject)
 	if ds.HasError() {
 		return ds
 	}
@@ -136,7 +137,7 @@ func resourceRoleBindingDelete(_ context.Context, d *schema.ResourceData, meta i
 	if project == "" {
 		project = wildcardProject
 	}
-	client, ds := newClient(config, project)
+	client, ds := getClient(config, project)
 	if ds.HasError() {
 		return ds
 	}

--- a/nobl9/resource_service.go
+++ b/nobl9/resource_service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -79,7 +80,7 @@ func unmarshalService(d *schema.ResourceData, objects []n9api.AnyJSONObj) diag.D
 
 func resourceServiceApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds != nil {
 		return ds
 	}
@@ -109,7 +110,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		// project is empty when importing
 		project = config.Project
 	}
-	client, ds := newClient(config, project)
+	client, ds := getClient(config, project)
 	if ds.HasError() {
 		return ds
 	}
@@ -124,7 +125,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -278,7 +279,7 @@ func schemaSLO() map[string]*schema.Schema {
 
 func resourceSLOApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds != nil {
 		return ds
 	}
@@ -308,7 +309,7 @@ func resourceSLORead(_ context.Context, d *schema.ResourceData, meta interface{}
 		// project is empty when importing
 		project = config.Project
 	}
-	client, ds := newClient(config, project)
+	client, ds := getClient(config, project)
 	if ds.HasError() {
 		return ds
 	}
@@ -323,7 +324,7 @@ func resourceSLORead(_ context.Context, d *schema.ResourceData, meta interface{}
 
 func resourceSLODelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
-	client, ds := newClient(config, d.Get("project").(string))
+	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}


### PR DESCRIPTION
Every new N9 client calls Okta for a new auth token. Because of that,
 we're hitting Okta's rate limits.

Now N9 client is created once on the first call and cached for subsequent calls to the API.

We took into consideration using the client's pool in the provider and changing SDK to support more concurrent connections, but now it seems to be a bit over-engineering since TF by default only runs 10 concurrent operations.

Resolves: PC-6512