### PR TITLE
 reuse n9 client per project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=nobl9.com
 NAMESPACE=nobl9
 NAME=nobl9
 BINARY=terraform-provider-${NAME}
-VERSION=0.6.3
+VERSION=0.6.4
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.6.3"
+      version = "0.6.4"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.6.3"
+      version = "0.6.4"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.6.3"
+      version = "0.6.4"
     }
   }
 }

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -119,6 +119,7 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 var (
 	clients   map[string]*nobl9.Client
 	clientErr error
+	mu        sync.Mutex
 	once      sync.Once
 )
 
@@ -135,6 +136,8 @@ func getClient(config ProviderConfig, project string) (*nobl9.Client, diag.Diagn
 			config.OktaAuthServer,
 		)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 
 	once.Do(func() {
 		clients = make(map[string]*nobl9.Client)

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -117,6 +117,10 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 
 //nolint:gochecknoglobals
 var (
+	// The N9 TF Provider supports the creation of project types. This means that the project can be different (or even
+	// missing during TF import) between requests to the N9 API. The N9 SDK requires a project to be passed when
+	// creating a new API client, and reuses this project for each call. To avoid breaking the current SDK interface,
+	// provider creates the client per project.
 	clients   map[string]*nobl9.Client
 	clientErr error
 	mu        sync.Mutex

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -117,11 +117,11 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 
 //nolint:gochecknoglobals
 var (
-	// The N9 TF Provider supports the creation of project types. This means that the project can be different (or even
+	// The N9 TF Provider supports the creation of project kind. This means that the project can be different (or even
 	// missing during TF import) between requests to the N9 API. The N9 SDK requires a project to be passed when
 	// creating a new API client, and reuses this project for each call. To avoid breaking the current SDK interface,
 	// provider creates the client per project.
-	clients   map[string]*nobl9.Client
+	clients   = make(map[string]*nobl9.Client)
 	clientErr error
 	mu        sync.Mutex
 	once      sync.Once
@@ -142,11 +142,6 @@ func getClient(config ProviderConfig, project string) (*nobl9.Client, diag.Diagn
 	}
 	mu.Lock()
 	defer mu.Unlock()
-
-	once.Do(func() {
-		clients = make(map[string]*nobl9.Client)
-		clients[project], clientErr = newClient()
-	})
 
 	client, clientInitialized := clients[project]
 	if !clientInitialized {

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -117,10 +117,9 @@ func providerConfigure(_ context.Context, data *schema.ResourceData) (interface{
 
 //nolint:gochecknoglobals
 var (
-	client    *nobl9.Client
+	clients   map[string]*nobl9.Client
 	clientErr error
 	once      sync.Once
-	clients   map[string]*nobl9.Client
 )
 
 func getClient(config ProviderConfig, project string) (*nobl9.Client, diag.Diagnostics) {

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -124,7 +124,6 @@ var (
 	clients   = make(map[string]*nobl9.Client)
 	clientErr error
 	mu        sync.Mutex
-	once      sync.Once
 )
 
 func getClient(config ProviderConfig, project string) (*nobl9.Client, diag.Diagnostics) {

--- a/nobl9/provider_test.go
+++ b/nobl9/provider_test.go
@@ -75,7 +75,7 @@ func CheckObjectCreated(name string) resource.TestCheckFunc {
 	}
 }
 
-func CheckDestory(rsType string, objectType n9api.Object) func(s *terraform.State) error {
+func CheckDestroy(rsType string, objectType n9api.Object) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config, ok := testProvider.Meta().(ProviderConfig)
 		if !ok {

--- a/nobl9/resource_agent_test.go
+++ b/nobl9/resource_agent_test.go
@@ -43,7 +43,7 @@ func TestAcc_Nobl9Agent(t *testing.T) {
 			resource.Test(t, resource.TestCase{
 				PreCheck:          func() { testAccPreCheck(t) },
 				ProviderFactories: ProviderFactory(),
-				CheckDestroy:      CheckDestory("nobl9_agent", n9api.ObjectAgent),
+				CheckDestroy:      CheckDestroy("nobl9_agent", n9api.ObjectAgent),
 				Steps: []resource.TestStep{
 					{
 						Config: tc.configFunc(tc.name),

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -53,7 +54,7 @@ func destroyMultiple(rsTypes []string, objectTypes []n9api.Object) resource.Test
 			return fmt.Errorf("resource_types (%v) must match objectTypes (%v)", rsTypes, objectTypes)
 		}
 		for i := 0; i < len(rsTypes); i++ {
-			CheckDestory(rsTypes[i], objectTypes[i])
+			CheckDestroy(rsTypes[i], objectTypes[i])
 		}
 		return nil
 	}

--- a/nobl9/resource_alertmethod_test.go
+++ b/nobl9/resource_alertmethod_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -31,7 +32,7 @@ func TestAcc_Nobl9AlertMethod(t *testing.T) {
 			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:          func() { testAccPreCheck(t) },
 				ProviderFactories: ProviderFactory(),
-				CheckDestroy:      CheckDestory("nobl9_alert_method_"+tc.resourceSuffix, n9api.ObjectAlertMethod),
+				CheckDestroy:      CheckDestroy("nobl9_alert_method_"+tc.resourceSuffix, n9api.ObjectAlertMethod),
 				Steps: []resource.TestStep{
 					{
 						Config: tc.configFunc(tc.name),

--- a/nobl9/resource_project_test.go
+++ b/nobl9/resource_project_test.go
@@ -15,7 +15,7 @@ func TestAcc_Nobl9Project(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: ProviderFactory(),
-		CheckDestroy:      CheckDestory("nobl9_project", n9api.ObjectProject),
+		CheckDestroy:      CheckDestroy("nobl9_project", n9api.ObjectProject),
 		Steps: []resource.TestStep{
 			{
 				Config: testProjectConfig(name),
@@ -24,6 +24,40 @@ func TestAcc_Nobl9Project(t *testing.T) {
 			{
 				Config: testProjectConfigNoLabels(name),
 				Check:  CheckObjectCreated("nobl9_project." + name),
+			},
+		},
+	})
+}
+
+func TestAcc_NewNobl9ProjectReference(t *testing.T) {
+	name := "test-project"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: ProviderFactory(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			CheckDestroy("nobl9_agent", n9api.ObjectAgent),
+			CheckDestroy("nobl9_project", n9api.ObjectProject),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "nobl9_project" "%s" {
+					  display_name = "%s"
+					  name         = "%s"
+					  description  = "A terraform project"
+					}
+					resource "nobl9_agent" "%s" {
+					 name      = "%s"
+					 project   = nobl9_project.%s.name
+					 source_of = ["Metrics", "Services"]
+					 agent_type = "bigquery"
+					}
+				`, name, name, name, name, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					CheckObjectCreated("nobl9_project."+name),
+					CheckObjectCreated("nobl9_agent."+name),
+				),
 			},
 		},
 	})

--- a/nobl9/resource_role_binding_test.go
+++ b/nobl9/resource_role_binding_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -25,7 +26,7 @@ func TestAcc_Nobl9RoleBinding(t *testing.T) {
 			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:          func() { testAccPreCheck(t) },
 				ProviderFactories: ProviderFactory(),
-				CheckDestroy:      CheckDestory("nobl9_role_binding", n9api.ObjectRoleBinding),
+				CheckDestroy:      CheckDestroy("nobl9_role_binding", n9api.ObjectRoleBinding),
 				Steps: []resource.TestStep{
 					{
 						Config: tc.configFunc(tc.name),

--- a/nobl9/resource_service_test.go
+++ b/nobl9/resource_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -13,7 +14,7 @@ func TestAcc_Nobl9Service(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: ProviderFactory(),
-		CheckDestroy:      CheckDestory("nobl9_service", n9api.ObjectService),
+		CheckDestroy:      CheckDestroy("nobl9_service", n9api.ObjectService),
 		Steps: []resource.TestStep{
 			{
 				Config: testService("test-service"),

--- a/nobl9/resource_slo_test.go
+++ b/nobl9/resource_slo_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	n9api "github.com/nobl9/nobl9-go"
 )
 
@@ -54,7 +55,7 @@ func TestAcc_Nobl9SLO(t *testing.T) {
 			resource.Test(t, resource.TestCase{
 				PreCheck:          func() { testAccPreCheck(t) },
 				ProviderFactories: ProviderFactory(),
-				CheckDestroy:      CheckDestory("nobl9_slo", n9api.ObjectSLO),
+				CheckDestroy:      CheckDestroy("nobl9_slo", n9api.ObjectSLO),
 				Steps: []resource.TestStep{
 					{
 						Config: tc.configFunc(tc.name),


### PR DESCRIPTION
Reusing the N9 client for all API calls caused using an invalid project
for some of the requests. Now clients are created per individual
project.

Resolves: PC-6512