### PR TITLE
Add Ratio Metric Example to docs

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -43,12 +43,12 @@ resource "nobl9_slo" "this" {
   }
 
   attachment {
-    utl = "https://www.nobl9.com/"
+    utl          = "https://www.nobl9.com/"
     display_name = "SLO provider"
   }
 
   attachment {
-    utl = "https://duckduckgo.com/"
+    utl          = "https://duckduckgo.com/"
     display_name = "Nice search engine"
   }
 
@@ -68,12 +68,51 @@ resource "nobl9_slo" "this" {
     display_name = "OK"
     value        = 2000
     op           = "gte"
+    
     raw_metric {
       query {
         prometheus {
           promql = <<EOT
           latency_west_c7{code="ALL",instance="localhost:3000",job="prometheus",service="globacount"}
           EOT
+        }
+      }
+    }
+  }
+
+  indicator {
+    name = "test-terraform-prom-agent"
+  }
+}
+
+resource "nobl9_slo" "this" {
+  name             = "${nobl9_project.this.name}-ratio"
+  service          = nobl9_service.this.name
+  budgeting_method = "Occurrences"
+  project          = nobl9_project.this.name
+
+  time_window {
+    unit       = "Day"
+    count      = 30
+    is_rolling = true
+  }
+
+  objective {
+    name         = "tf-objective-1"
+    target       = 0.99
+    display_name = "OK"
+    value        = 1
+
+    count_metrics {
+      incremental = true
+      good {
+        prometheus {
+          promql = "1.0"
+        }
+      }
+      total {
+        prometheus {
+          promql = "1.0"
         }
       }
     }

--- a/examples/resources/nobl9_slo/resource.tf
+++ b/examples/resources/nobl9_slo/resource.tf
@@ -28,12 +28,12 @@ resource "nobl9_slo" "this" {
   }
 
   attachment {
-    utl = "https://www.nobl9.com/"
+    utl          = "https://www.nobl9.com/"
     display_name = "SLO provider"
   }
 
   attachment {
-    utl = "https://duckduckgo.com/"
+    utl          = "https://duckduckgo.com/"
     display_name = "Nice search engine"
   }
 
@@ -53,6 +53,7 @@ resource "nobl9_slo" "this" {
     display_name = "OK"
     value        = 2000
     op           = "gte"
+    
     raw_metric {
       query {
         prometheus {
@@ -69,3 +70,40 @@ resource "nobl9_slo" "this" {
   }
 }
 
+resource "nobl9_slo" "this" {
+  name             = "${nobl9_project.this.name}-ratio"
+  service          = nobl9_service.this.name
+  budgeting_method = "Occurrences"
+  project          = nobl9_project.this.name
+
+  time_window {
+    unit       = "Day"
+    count      = 30
+    is_rolling = true
+  }
+
+  objective {
+    name         = "tf-objective-1"
+    target       = 0.99
+    display_name = "OK"
+    value        = 1
+
+    count_metrics {
+      incremental = true
+      good {
+        prometheus {
+          promql = "1.0"
+        }
+      }
+      total {
+        prometheus {
+          promql = "1.0"
+        }
+      }
+    }
+  }
+
+  indicator {
+    name = "test-terraform-prom-agent"
+  }
+}


### PR DESCRIPTION
There is no example how to use Ratio Metric (a.k.a. count metrics) in n9 via terraform provider. I added this example to the standard SLO page.
It will appear [here](https://registry.terraform.io/providers/nobl9/nobl9/latest/docs/resources/slo#example-usage)