### PR TITLE
Fix inconsistent role bindings

### DIFF
--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -2,6 +2,7 @@ package nobl9
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -53,6 +54,7 @@ func resourceRoleBinding() *schema.Resource {
 
 func marshalRoleBinding(d *schema.ResourceData) *n9api.RoleBinding {
 	name := d.Get("name").(string)
+	project := d.Get("project_ref").(string)
 	if name == "" {
 		id, _ := uuid.NewUUID() // NewUUID returns always nil error
 		name = id.String()
@@ -61,14 +63,21 @@ func marshalRoleBinding(d *schema.ResourceData) *n9api.RoleBinding {
 		APIVersion: n9api.APIVersion,
 		Kind:       n9api.KindRoleBinding,
 		Metadata: n9api.RoleBindingMetadata{
-			Name: name,
+			Name: createName(name, project),
 		},
 		Spec: n9api.RoleBindingSpec{
 			User:       d.Get("user").(string),
 			RoleRef:    d.Get("role_ref").(string),
-			ProjectRef: d.Get("project_ref").(string),
+			ProjectRef: project,
 		},
 	}
+}
+
+func createName(name, project string) string {
+	if project != "" {
+		return fmt.Sprintf("%s-%s", name, project)
+	}
+	return name
 }
 
 func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) diag.Diagnostics {

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -98,7 +98,7 @@ func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) di
 // If api return to us more than one role binding (when there are two roles bindings with same name)
 // we specify which one should be processed by checking if project is not empty.
 func getRoleBindingByType(d *schema.ResourceData, objects []n9api.AnyJSONObj) n9api.AnyJSONObj {
-	if d.Get("project_ref") != "" && objects[0]["project_id"] == nil {
+	if !resourceAndObjectAreProjectRole(d, objects[0]) {
 		if len(objects) == 2 {
 			return objects[1]
 		} else if len(objects) <= 1 {
@@ -107,6 +107,10 @@ func getRoleBindingByType(d *schema.ResourceData, objects []n9api.AnyJSONObj) n9
 		}
 	}
 	return objects[0]
+}
+
+func resourceAndObjectAreProjectRole(d *schema.ResourceData, object n9api.AnyJSONObj) bool {
+	return d.Get("project_ref") != "" && object["project_id"] != nil
 }
 
 func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -98,7 +98,7 @@ func findRoleBindingByType(projectRole bool, objects []n9api.AnyJSONObj) n9api.A
 	for _, object := range objects {
 		if projectRole && containsProjectRef(object) {
 			return object
-		} else if !projectRole && containsProjectRef(object) {
+		} else if !projectRole && !containsProjectRef(object) {
 			return object
 		}
 	}

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -96,13 +96,18 @@ func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) di
 
 func findRoleBindingByType(projectRole bool, objects []n9api.AnyJSONObj) n9api.AnyJSONObj {
 	for _, object := range objects {
-		if projectRole && object["project_id"] != nil {
+		if projectRole && containsProjectRef(object) {
 			return object
-		} else if !projectRole && object["project_id"] == nil {
+		} else if !projectRole && containsProjectRef(object) {
 			return object
 		}
 	}
 	return nil
+}
+
+func containsProjectRef(obj n9api.AnyJSONObj) bool {
+	spec := obj["spec"].(map[string]interface{})
+	return spec["projectRef"] != nil
 }
 
 func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -75,14 +75,14 @@ func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) di
 		d.SetId("")
 		return nil
 	}
-	object := getCorrectObject(d, objects)
+	roleBinding := getRoleBindingByType(d, objects)
 	var diags diag.Diagnostics
 
-	metadata := object["metadata"].(map[string]interface{})
+	metadata := roleBinding["metadata"].(map[string]interface{})
 	err := d.Set("name", metadata["name"])
 	diags = appendError(diags, err)
 
-	spec := object["spec"].(map[string]interface{})
+	spec := roleBinding["spec"].(map[string]interface{})
 	err = d.Set("user", spec["user"])
 	diags = appendError(diags, err)
 	err = d.Set("role_ref", spec["roleRef"])
@@ -93,10 +93,12 @@ func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) di
 	return diags
 }
 
-// getCorrectObject check if this is organization role or project role by checking if project_ref was defined
-// and returns correct one. Check happens only if we have two role bindings with same name for organization role and
-// project role
-func getCorrectObject(d *schema.ResourceData, objects []n9api.AnyJSONObj) n9api.AnyJSONObj {
+// getRoleBindingByType returns role binding depending on type that was applied
+//
+// Role bindings have two types, organization role and project role, both can have same name.
+// If api return to us more than one role binding (when there are two roles bindings with same name)
+// we specify which one should be processed by checking if project is not empty.
+func getRoleBindingByType(d *schema.ResourceData, objects []n9api.AnyJSONObj) n9api.AnyJSONObj {
 	if len(objects) == 1 {
 		return objects[0]
 	}


### PR DESCRIPTION
Before this change we were able to apply two role bindings one for organization role and one for project role. Terraform query for role bindings by name. This condition caused to throw error by terraform. (WE apply resource and check if it was applied)
``` go 
func unmarshalRoleBinding(d *schema.ResourceData, objects []n9api.AnyJSONObj) diag.Diagnostics {
	if len(objects) != 1 {
		d.SetId("")
		return nil
	}
```
Apply of resource that is after returned as nil cause this error.
```
Error: Provider produced inconsistent result after apply
```

To fix this issue I'm checking if role is project role or organization role by looking in project_ref is set. 