### PR TITLE
Retry for concurrent issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
-	github.com/nobl9/nobl9-go v0.4.0
+	github.com/nobl9/nobl9-go v0.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nobl9/nobl9-go v0.4.0 h1:iaW5YlB9Cdfibc4izQRaEMA+Q7LbwbNxqo3Kn1mDqaA=
-github.com/nobl9/nobl9-go v0.4.0/go.mod h1:V+SUN5VoHZrBtNQ7ghBEFIzqHw/IWPzWAm6KF4agKvE=
+github.com/nobl9/nobl9-go v0.6.0 h1:K059J6SGGcBvsaNQvz1XOHwMhPzD/VHufZGHwdRorrE=
+github.com/nobl9/nobl9-go v0.6.0/go.mod h1:V+SUN5VoHZrBtNQ7ghBEFIzqHw/IWPzWAm6KF4agKvE=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -2,6 +2,7 @@ package nobl9
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/nobl9/nobl9-go"
@@ -12,6 +13,7 @@ import (
 
 //nolint:gochecknoglobals,revive
 var Version string
+var ErrConcurrencyIssue = errors.New("operation failed due to concurrency issue but can be retried")
 
 func Provider() *schema.Provider {
 	return &schema.Provider{

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -2,7 +2,6 @@ package nobl9
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"github.com/nobl9/nobl9-go"
@@ -13,7 +12,6 @@ import (
 
 //nolint:gochecknoglobals,revive
 var Version string
-var ErrConcurrencyIssue = errors.New("operation failed due to concurrency issue but can be retried")
 
 func Provider() *schema.Provider {
 	return &schema.Provider{

--- a/nobl9/resource_agent.go
+++ b/nobl9/resource_agent.go
@@ -122,7 +122,7 @@ func resourceAgentApply(ctx context.Context, d *schema.ResourceData, meta interf
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
 		agentsData, err := client.ApplyAgents(p.GetObjects())
 		if err != nil {
-			if errors.Is(err, ErrConcurrencyIssue) {
+			if errors.As(err, &ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -175,7 +175,7 @@ func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
 		err := client.DeleteObjectsByName(n9api.ObjectAgent, d.Id())
 		if err != nil {
-			if errors.Is(err, ErrConcurrencyIssue) {
+			if errors.As(err, &ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/nobl9/resource_agent.go
+++ b/nobl9/resource_agent.go
@@ -3,11 +3,14 @@ package nobl9
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	n9api "github.com/nobl9/nobl9-go"
@@ -116,16 +119,23 @@ func resourceAgentApply(ctx context.Context, d *schema.ResourceData, meta interf
 	var p n9api.Payload
 	p.AddObject(agent)
 
-	agentsData, err := client.ApplyAgents(p.GetObjects())
-	if err != nil {
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
+		agentsData, err := client.ApplyAgents(p.GetObjects())
+		if err != nil {
+			if errors.Is(err, ErrConcurrencyIssue) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		if len(agentsData) == 1 {
+			err = d.Set("client_id", agentsData[0].ClientID)
+			diags = appendError(diags, err)
+			err = d.Set("client_secret", agentsData[0].ClientSecret)
+			diags = appendError(diags, err)
+		}
+		return nil
+	}); err != nil {
 		return diag.Errorf("could not add agent: %s", err.Error())
-	}
-
-	if len(agentsData) == 1 {
-		err = d.Set("client_id", agentsData[0].ClientID)
-		diags = appendError(diags, err)
-		err = d.Set("client_secret", agentsData[0].ClientSecret)
-		diags = appendError(diags, err)
 	}
 
 	d.SetId(agent.Metadata.Name)
@@ -155,15 +165,23 @@ func resourceAgentRead(_ context.Context, d *schema.ResourceData, meta interface
 	return unmarshalAgent(d, objects)
 }
 
-func resourceAgentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
 	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}
 
-	err := client.DeleteObjectsByName(n9api.ObjectAgent, d.Id())
-	if err != nil {
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
+		err := client.DeleteObjectsByName(n9api.ObjectAgent, d.Id())
+		if err != nil {
+			if errors.Is(err, ErrConcurrencyIssue) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/nobl9/resource_agent.go
+++ b/nobl9/resource_agent.go
@@ -122,7 +122,7 @@ func resourceAgentApply(ctx context.Context, d *schema.ResourceData, meta interf
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
 		agentsData, err := client.ApplyAgents(p.GetObjects())
 		if err != nil {
-			if errors.As(err, &ErrConcurrencyIssue) {
+			if errors.Is(err, n9api.ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -175,7 +175,7 @@ func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
 		err := client.DeleteObjectsByName(n9api.ObjectAgent, d.Id())
 		if err != nil {
-			if errors.As(err, &ErrConcurrencyIssue) {
+			if errors.Is(err, n9api.ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -112,7 +112,7 @@ func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta 
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
 		err := client.ApplyObjects(p.GetObjects())
 		if err != nil {
-			if errors.Is(err, ErrConcurrencyIssue) {
+			if errors.As(err, &ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -156,7 +156,7 @@ func resourceRoleBindingDelete(ctx context.Context, d *schema.ResourceData, meta
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
 		err := client.DeleteObjectsByName(n9api.ObjectRoleBinding, d.Id())
 		if err != nil {
-			if errors.Is(err, ErrConcurrencyIssue) {
+			if errors.As(err, &ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -112,7 +112,7 @@ func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta 
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
 		err := client.ApplyObjects(p.GetObjects())
 		if err != nil {
-			if errors.As(err, &ErrConcurrencyIssue) {
+			if errors.Is(err, n9api.ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -156,7 +156,7 @@ func resourceRoleBindingDelete(ctx context.Context, d *schema.ResourceData, meta
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
 		err := client.DeleteObjectsByName(n9api.ObjectRoleBinding, d.Id())
 		if err != nil {
-			if errors.As(err, &ErrConcurrencyIssue) {
+			if errors.Is(err, n9api.ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/nobl9/resource_role_binding.go
+++ b/nobl9/resource_role_binding.go
@@ -2,9 +2,12 @@ package nobl9
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	n9api "github.com/nobl9/nobl9-go"
@@ -106,8 +109,16 @@ func resourceRoleBindingApply(ctx context.Context, d *schema.ResourceData, meta 
 	var p n9api.Payload
 	p.AddObject(ap)
 
-	err := client.ApplyObjects(p.GetObjects())
-	if err != nil {
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
+		err := client.ApplyObjects(p.GetObjects())
+		if err != nil {
+			if errors.Is(err, ErrConcurrencyIssue) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		return diag.Errorf("could not add project: %s", err.Error())
 	}
 
@@ -131,7 +142,7 @@ func resourceRoleBindingRead(_ context.Context, d *schema.ResourceData, meta int
 	return unmarshalRoleBinding(d, objects)
 }
 
-func resourceRoleBindingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRoleBindingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
 	project := d.Get("project_ref").(string)
 	if project == "" {
@@ -142,8 +153,16 @@ func resourceRoleBindingDelete(_ context.Context, d *schema.ResourceData, meta i
 		return ds
 	}
 
-	err := client.DeleteObjectsByName(n9api.ObjectRoleBinding, d.Id())
-	if err != nil {
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
+		err := client.DeleteObjectsByName(n9api.ObjectRoleBinding, d.Id())
+		if err != nil {
+			if errors.Is(err, ErrConcurrencyIssue) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -336,7 +336,7 @@ func resourceSLOApply(ctx context.Context, d *schema.ResourceData, meta interfac
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
 		err := client.ApplyObjects(p.GetObjects())
 		if err != nil {
-			if errors.As(err, &ErrConcurrencyIssue) {
+			if errors.Is(err, n9api.ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -381,7 +381,7 @@ func resourceSLODelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete)-time.Minute, func() *resource.RetryError {
 		err := client.DeleteObjectsByName(n9api.ObjectSLO, d.Id())
 		if err != nil {
-			if errors.As(err, &ErrConcurrencyIssue) {
+			if errors.Is(err, n9api.ErrConcurrencyIssue) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -2,15 +2,20 @@ package nobl9
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	n9api "github.com/nobl9/nobl9-go"
 )
+
+var ErrConcurrencyIssue = errors.New("operation failed due to concurrency issue but can be retried")
 
 func resourceSLO() *schema.Resource {
 	return &schema.Resource{
@@ -330,9 +335,17 @@ func resourceSLOApply(ctx context.Context, d *schema.ResourceData, meta interfac
 	var p n9api.Payload
 	p.AddObject(slo)
 
-	err := client.ApplyObjects(p.GetObjects())
-	if err != nil {
-		return diag.Errorf("could not add SLO: %s", err.Error())
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
+		err := client.ApplyObjects(p.GetObjects())
+		if err != nil {
+			if errors.Is(err, ErrConcurrencyIssue) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(slo.Metadata.Name)
@@ -360,15 +373,23 @@ func resourceSLORead(_ context.Context, d *schema.ResourceData, meta interface{}
 	return unmarshalSLO(d, objects)
 }
 
-func resourceSLODelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSLODelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
 	client, ds := getClient(config, d.Get("project").(string))
 	if ds.HasError() {
 		return ds
 	}
 
-	err := client.DeleteObjectsByName(n9api.ObjectSLO, d.Id())
-	if err != nil {
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
+		err := client.DeleteObjectsByName(n9api.ObjectSLO, d.Id())
+		if err != nil {
+			if errors.Is(err, ErrConcurrencyIssue) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
##  Retry mechanism 
This PR introduces retry mechanism for resources that their may fail due nobl9 internal service problem with concurrent requests. Retrying this requests always solve this issue. It is done by using terraform sdk [resource.RetryContext](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts#:~:text=WithoutTimeout%20CRUD%20functions.-,Retry,-The%20retry%20helper) function. 

## Affected resources 
This functionality is implemented:
- slos, 
- role bindings,
- agents.

For operations:
- apply,
-  update,
- delete.

## How to test
If it will be tested before releasing new nobl9-go it need to have that replace in go.mod and run `go mod tidy` 
```
replace github.com/nobl9/nobl9-go => github.com/nobl9/nobl9-go 3764bbec8a5200d51a497c0def3f8a17e1b2f272
```

Easiest way to test this is to apply git number of changes resources(100 is always enough). Before change you should get error like this one 
```
╷
│ Error: could not add agent: operation failed due to concurrency issue but can be retried
│ 
│   with nobl9_agent.web-prom-95,
│   on main.tf line 1016, in resource "nobl9_agent" "web-prom-95":
│ 1016: 	 resource "nobl9_agent" "web-prom-95" {
│ 

```
 after changes resources should apply always without any issue related to concurrency or sql. 

## Related issues
Agents get applied pretty slow but it is different issue that shoudn't be solved in this issue (100 agents applies for about 7 minutes). 

## Timeouts value

Default timeout for CRUD functions in terraform is 20 minutes. This value in here is decreased by 1 minute as [docs](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts#:~:text=Copy-,Important,-If%20using%20a%20CRUD%20function%20with%20a%20timeout%2C%20any%20Retry) recommends. 

User can easly change timeout value in resource definition. Below example will change timeour for creating resources to 60minutes. 
```
resource "example_thing" "example" {
  # ...

  timeouts {
    create = "60m"
  }
}
```