### PR TITLE
Change metric_spec to required

### DIFF
--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -396,8 +396,6 @@ func resourceSLODelete(ctx context.Context, d *schema.ResourceData, meta interfa
 }
 
 func schemaMetricSpec() *schema.Schema {
-	metricSchema := map[string]*schema.Schema{}
-
 	metricSchemaDefinitions := []map[string]*schema.Schema{
 		schemaMetricAmazonPrometheus(),
 		schemaMetricAppDynamics(),
@@ -422,15 +420,16 @@ func schemaMetricSpec() *schema.Schema {
 		schemaMetricSumologic(),
 		schemaMetricThousandEyes(),
 	}
+	metricSchema := make(map[string]*schema.Schema, len(metricSchemaDefinitions))
 	for _, metricSchemaDef := range metricSchemaDefinitions {
-		for agentKey, schema := range metricSchemaDef {
-			metricSchema[agentKey] = schema
+		for agentKey, sch := range metricSchemaDef {
+			metricSchema[agentKey] = sch
 		}
 	}
 
 	return &schema.Schema{
 		Type:        schema.TypeSet,
-		Optional:    true,
+		Required:    true,
 		Description: "Configuration for metric source",
 		Elem: &schema.Resource{
 			Schema: metricSchema,

--- a/nobl9/resource_slo_test.go
+++ b/nobl9/resource_slo_test.go
@@ -80,7 +80,11 @@ func TestAcc_Nobl9SLOErrors(t *testing.T) {
 	}{
 		{"test-prom-with-conflict-attachments",
 			testPrometheusWithAttachmentsConflict,
-			"\"attachments\": conflicts with attachment",
+			`attachments": conflicts with attachment`,
+		},
+		{"test-metric-spec-required",
+			testMetricSpecRequired,
+			`At least 1 "total" blocks are required`,
 		},
 	}
 
@@ -2558,6 +2562,66 @@ func testAnomalyConfigNoDataDifferentProject(name string) string {
 	config = strings.ReplaceAll(config, ":project", testProject)
 	config = strings.ReplaceAll(config, ":alertMethodName", alertMethodName)
 	config = strings.ReplaceAll(config, ":alertMethodProject", alertMethodProject)
+
+	return config
+}
+
+func testMetricSpecRequired(name string) string {
+	var serviceName = name + "-tf-service"
+	var agentName = name + "-tf-agent"
+	config :=
+		testService(serviceName) +
+			testPrometheusAgent(agentName) + `
+resource "nobl9_slo" ":name" {
+  name         = ":name"
+  display_name = ":name"
+  project      = ":project"
+  service      = nobl9_service.:serviceName.name
+
+  label {
+   key = "team"
+   values = ["green","sapphire"]
+  }
+
+  label {
+   key = "env"
+   values = ["dev", "staging", "prod"]
+  }
+
+  budgeting_method = "Occurrences"
+
+  objective {
+    display_name = "obj1"
+    name         = "tf-objective-1"
+    target       = 0.7
+    value        = 1
+    count_metrics {
+      incremental = true
+      good {
+            prometheus {
+                promql = "1.0"
+            }
+      }
+    }
+  }
+
+  time_window {
+    count      = 10
+    is_rolling = true
+    unit       = "Minute"
+  }
+
+  indicator {
+    name    = nobl9_agent.:agentName.name
+    project = ":project"
+    kind    = "Agent"
+  }
+}
+`
+	config = strings.ReplaceAll(config, ":name", name)
+	config = strings.ReplaceAll(config, ":serviceName", serviceName)
+	config = strings.ReplaceAll(config, ":agentName", agentName)
+	config = strings.ReplaceAll(config, ":project", testProject)
 
 	return config
 }


### PR DESCRIPTION
When `total` or `good` metric spec for `count_metric` was not provided it ended up with index out of range error. `total` and `good` should both be required in the schema, instead they were marked as optionl.
I tested it by running all the tests, here's how to do that: https://nobl9.atlassian.net/wiki/spaces/FOUNDATIONS/pages/2255486981/Configuring+environments+for+Terraform