### PR TITLE
Make email subject and body optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=nobl9.com
 NAMESPACE=nobl9
 NAME=nobl9
 BINARY=terraform-provider-${NAME}
-VERSION=0.13.0
+VERSION=0.14.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.13.0"
+      version = "0.14.0"
     }
   }
 }

--- a/docs/resources/alert_method_email.md
+++ b/docs/resources/alert_method_email.md
@@ -24,8 +24,6 @@ resource "nobl9_alert_method_email" "this" {
   to		  = [ "testUser@nobl9.com" ]
   cc		  = [ "testUser@nobl9.com" ]
   bcc		  = [ "testUser@nobl9.com" ]
-  subject     = "Test email, please ignore"
-  body        = "This is just a test email"
 }
 ```
 
@@ -34,18 +32,18 @@ resource "nobl9_alert_method_email" "this" {
 
 ### Required
 
-- `body` (String) The Body of the email alert. For the format of the body and the list of variables that you can define, refer to the [Nobl9 documentation](https://docs.nobl9.com/Alerting/Alert_methods/email-alert#yaml-configuration).
 - `name` (String) Unique name of the resource, must conform to the naming convention from [DNS RFC1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
 - `project` (String) Name of the Nobl9 project the resource sits in, must conform to the naming convention from [DNS RFC1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-- `subject` (String) The Subject of the email alert.
 - `to` (List of String) Recipients. The maximum number of recipients is 10.
 
 ### Optional
 
 - `bcc` (List of String) Blind carbon copy recipients. The maximum number of recipients is 10.
+- `body` (String, Deprecated) Deprecated value that was used as the body template of email alert. It's not used anywhere but kept for backward compatibility.
 - `cc` (List of String) Carbon copy recipients. The maximum number of recipients is 10.
 - `description` (String) Optional description of the resource. Here, you can add details about who is responsible for the integration (team/owner) or the purpose of creating it.
 - `display_name` (String) User-friendly display name of the resource.
+- `subject` (String, Deprecated) Deprecated value that was used as the subject of email alert. It's not used anywhere but kept for backward compatibility.
 
 ### Read-Only
 

--- a/examples/resources/nobl9_alert_method_email/resource.tf
+++ b/examples/resources/nobl9_alert_method_email/resource.tf
@@ -6,7 +6,5 @@ resource "nobl9_alert_method_email" "this" {
   to		  = [ "testUser@nobl9.com" ]
   cc		  = [ "testUser@nobl9.com" ]
   bcc		  = [ "testUser@nobl9.com" ]
-  subject     = "Test email, please ignore"
-  body        = "This is just a test email"
 }
 

--- a/nobl9/resource_alertmethod.go
+++ b/nobl9/resource_alertmethod.go
@@ -529,13 +529,15 @@ func (i alertMethodEmail) GetSchema() map[string]*schema.Schema {
 		},
 		"subject": {
 			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The Subject of the email alert.",
+			Optional:    true,
+			Deprecated:  "Email Subject is Deprecated as of Nobl9 1.57 release. It's not used for email generation. You can safely remove it from your configuration file.",
+			Description: "Deprecated value that was used as the subject of email alert. It's not used anywhere but kept for backward compatibility.",
 		},
 		"body": {
 			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The Body of the email alert. For the format of the body and the list of variables that you can define, refer to the [Nobl9 documentation](https://docs.nobl9.com/Alerting/Alert_methods/email-alert#yaml-configuration).",
+			Optional:    true,
+			Deprecated:  "Email Body is Deprecated as of Nobl9 1.57 release. It's not used for email generation. You can safely remove it from your configuration file.",
+			Description: "Deprecated value that was used as the body template of email alert. It's not used anywhere but kept for backward compatibility.",
 		},
 	}
 }

--- a/nobl9/resource_alertmethod_test.go
+++ b/nobl9/resource_alertmethod_test.go
@@ -25,6 +25,7 @@ func TestAcc_Nobl9AlertMethod(t *testing.T) {
 		{"test-jira", "jira", testJiraConfig},
 		{"test-teams", "msteams", testTeamsConfig},
 		{"test-email", "email", testEmailConfig},
+		{"test-email-no-subject-and-body", "email", testEmailConfigWithoutSubjectAndBody},
 	}
 
 	for _, tc := range cases {
@@ -162,6 +163,19 @@ resource "nobl9_alert_method_email" "%s" {
   bcc		  = [ "testUser@nobl9.com" ]
   subject     = "Test email please ignore"
   body        = "This is just a test email"
+}
+`, name, name, testProject)
+}
+
+func testEmailConfigWithoutSubjectAndBody(name string) string {
+	return fmt.Sprintf(`
+resource "nobl9_alert_method_email" "%s" {
+  name        = "%s"
+  project     = "%s"
+  description = "teams"
+  to		  = [ "testUser@nobl9.com" ]
+  cc		  = [ "testUser@nobl9.com" ]
+  bcc		  = [ "testUser@nobl9.com" ]
 }
 `, name, name, testProject)
 }


### PR DESCRIPTION
## TLDR
The goal of this PR is to make email Subject and Body variables _Optional_ and _Deprecated_.
They are kept in the struct for backwards compatibility (to avoid breaking changes) but a Warning will appear whenever people have them in their config file. Example:
![image](https://github.com/nobl9/terraform-provider-nobl9/assets/22920797/bd44c7b0-9513-4091-9ec4-c1fc89986876)

## How to test
Apply scenario with subject and/or body in the structure
```
resource "nobl9_alert_method_email" "this" {
  name         = "my-email-alert"
  display_name = "My Email Alert"
  project      = "My Project"
  description = "teams"
  to          = [ "testUser@nobl9.com" ]
  cc          = [ "testUser@nobl9.com" ]
  bcc         = [ "testUser@nobl9.com" ]
  subject     = "Test email, please ignore"
  body        = "This is just a test email"
}
```
You should see warning in the console (about deprecated)

Apply case without them in the structure
```
resource "nobl9_alert_method_email" "this" {
  name         = "my-email-alert"
  display_name = "My Email Alert"
  project      = "My Project"
  description = "teams"
  to          = [ "testUser@nobl9.com" ]
  cc          = [ "testUser@nobl9.com" ]
  bcc         = [ "testUser@nobl9.com" ]
}
```
Apply should execute without warnings.