### PR TITLE
PC-9535: Add support for entire budget would be exhausted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=nobl9.com
 NAMESPACE=nobl9
 NAME=nobl9
 BINARY=terraform-provider-${NAME}
-VERSION=0.14.0
+VERSION=0.15.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.14.0"
+      version = "0.15.0"
     }
   }
 }

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -74,13 +74,13 @@ resource "nobl9_alert_policy" "this" {
 
 Required:
 
-- `measurement` (String) One of `timeToBurnBudget` | `burnRate` | `burnedBudget`.
+- `measurement` (String) One of `timeToBurnBudget` | `timeToBurnEntireBudget` | `burnRate` | `burnedBudget`.
 
 Optional:
 
 - `lasts_for` (String) Indicates how long a given condition needs to be valid to mark the condition as true.
 - `value` (Number) For `averageBurnRate`, it indicates how fast the error budget is burning. For `burnedBudget`, it tells how much error budget is already burned.
-- `value_string` (String) Used with `timeToBurnBudget`, indicates when the budget would be exhausted. The expected value is a string in time duration string format.
+- `value_string` (String) Used with `timeToBurnBudget` or `timeToBurnEntireBudget`, indicates when the budget would be exhausted. The expected value is a string in time duration string format.
 
 
 <a id="nestedblock--alert_method"></a>

--- a/nobl9/resource_alert_policy.go
+++ b/nobl9/resource_alert_policy.go
@@ -33,7 +33,7 @@ func resourceAlertPolicy() *schema.Resource {
 						"measurement": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "One of `timeToBurnBudget` | `burnRate` | `burnedBudget`.",
+							Description: "One of `timeToBurnBudget` | `timeToBurnEntireBudget` | `burnRate` | `burnedBudget`.",
 						},
 						"value": {
 							Type:        schema.TypeFloat,
@@ -43,7 +43,7 @@ func resourceAlertPolicy() *schema.Resource {
 						"value_string": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Used with `timeToBurnBudget`, indicates when the budget would be exhausted. The expected value is a string in time duration string format.",
+							Description: "Used with `timeToBurnBudget` or `timeToBurnEntireBudget`, indicates when the budget would be exhausted. The expected value is a string in time duration string format.",
 						},
 						"lasts_for": {
 							Type:        schema.TypeString,
@@ -170,7 +170,7 @@ func marshalAlertConditions(d *schema.ResourceData) []n9api.AlertCondition {
 
 		measurement := condition["measurement"].(string)
 		op := "gte"
-		if measurement == "timeToBurnBudget" {
+		if measurement == "timeToBurnBudget" || measurement == "timeToBurnEntireBudget" {
 			op = "lt"
 		}
 

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -79,6 +79,11 @@ resource "nobl9_alert_policy" "%s" {
 	}
 
   condition {
+	  measurement  = "timeToBurnEntireBudget"
+	  value_string = "1h"
+	}
+
+  condition {
 	  measurement  = "timeToBurnBudget"
 	  value_string = "1h"
 	  lasts_for	   = "300s"
@@ -110,6 +115,11 @@ resource "nobl9_alert_policy" "%s" {
 	measurement  = "timeToBurnBudget"
 	value_string = "1h"
 	lasts_for	   = "300s"
+  }
+
+  condition {
+	measurement  = "timeToBurnEntireBudget"
+	value_string = "1h"
   }
 
   alert_method {
@@ -144,6 +154,12 @@ resource "nobl9_alert_policy" "%s" {
     measurement  = "timeToBurnBudget"
     value_string = "1h"
     lasts_for	   = "300s"
+  }
+
+  condition {
+    measurement  = "timeToBurnEntireBudget"
+    value_string = "1h"
+    lasts_for	   = "60s"
   }
 
   alert_method {
@@ -183,6 +199,11 @@ resource "nobl9_alert_policy" "%s" {
     measurement  = "timeToBurnBudget"
     value_string = "1h"
     lasts_for	   = "300s"
+  }
+
+  condition {
+    measurement  = "timeToBurnEntireBudget"
+    value_string = "2h"
   }
 
   alert_method {


### PR DESCRIPTION
### Motivation

Introduced new measurement `timeToBurnEntireBudget` for alerting available to be configured with sloctl. We want to allow users to configure new condition type with Terraform too.

### Related changes
- https://github.com/nobl9/nobl9-go/pull/78

### Testing

Tested on dev-sapphire with `main.tf` and following this [steps](https://nobl9.atlassian.net/wiki/spaces/FOUNDATIONS/pages/2370797596/Terraform+releases):

```terraform
terraform {
  required_providers {
    nobl9 = {
      source  = "nobl9.com/nobl9/nobl9"
      version = "0.15.0"
    }
  }
}

provider "nobl9" {
  organization     = "nobl9-dev"
  project          = "default"
  ingest_url       = "https://dev-sapphire.nobl9.dev/api"
  okta_org_url     = "https://accounts.nobl9.dev"
  okta_auth_server = "ausdh506kj9JJVw3g4x6"
  client_id        = "<CLIENT_ID>"
  client_secret    = "<CLIENT_SECRET>"
}

resource "nobl9_project" "test" {
  name = "test"
}

resource "nobl9_service" "test" {
  name    = "test"
  project = "test"
}

resource "nobl9_alert_policy" "this" {
  name         = "ap-test"
  project      = "test"
  display_name = "Alert Policy Test"
  severity     = "High"

  condition {
    measurement  = "timeToBurnEntireBudget"
    value_string = "72h"
    lasts_for    = "30m"
  }
}
```

And locally:
```
make test

go test -i $(go list ./... | grep -v 'vendor') || exit 1
go: -i flag is deprecated
echo $(go list ./... | grep -v 'vendor') | xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/nobl9/terraform-provider-nobl9 github.com/nobl9/terraform-provider-nobl9/nobl9
?   	github.com/nobl9/terraform-provider-nobl9	[no test files]
ok  	github.com/nobl9/terraform-provider-nobl9/nobl9	0.590s
```