### PR TITLE
PC-9535: Fix for failing ACC tests

### DIFF
--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -20,6 +20,7 @@ func TestAcc_Nobl9AlertPolicy(t *testing.T) {
 		{"alert-policy-with-multi-alert-method", testAlertPolicyWithMultipleIntegration},
 		// This is coming from SRE-738 where the order of the alert methods was always showing a diff
 		{"alert-policy-with-multi-alert-method-reverse", testAlertPolicyWithMultipleIntegrationReverseOrder},
+		{"alert-policy-with-time-to-burn-entire-budget", testAlertPolicyWithTimeToBurnEntireBudgetCondition},
 	}
 
 	for _, tc := range cases {

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -79,11 +79,6 @@ resource "nobl9_alert_policy" "%s" {
 	}
 
   condition {
-	  measurement  = "timeToBurnEntireBudget"
-	  value_string = "1h"
-	}
-
-  condition {
 	  measurement  = "timeToBurnBudget"
 	  value_string = "1h"
 	  lasts_for	   = "300s"
@@ -115,11 +110,6 @@ resource "nobl9_alert_policy" "%s" {
 	measurement  = "timeToBurnBudget"
 	value_string = "1h"
 	lasts_for	   = "300s"
-  }
-
-  condition {
-	measurement  = "timeToBurnEntireBudget"
-	value_string = "1h"
   }
 
   alert_method {
@@ -154,12 +144,6 @@ resource "nobl9_alert_policy" "%s" {
     measurement  = "timeToBurnBudget"
     value_string = "1h"
     lasts_for	   = "300s"
-  }
-
-  condition {
-    measurement  = "timeToBurnEntireBudget"
-    value_string = "1h"
-    lasts_for	   = "60s"
   }
 
   alert_method {
@@ -201,11 +185,6 @@ resource "nobl9_alert_policy" "%s" {
     lasts_for	   = "300s"
   }
 
-  condition {
-    measurement  = "timeToBurnEntireBudget"
-    value_string = "2h"
-  }
-
   alert_method {
     project = "%s"
     name	= nobl9_alert_method_webhook.%s-am-two.name
@@ -217,4 +196,25 @@ resource "nobl9_alert_policy" "%s" {
   }
 }
 `, name, name, testProject, testProject, name, testProject, name)
+}
+
+func testAlertPolicyWithTimeToBurnEntireBudgetCondition(name string) string {
+	return fmt.Sprintf(`
+resource "nobl9_alert_policy" "%s" {
+  name       = "%s"
+  project    = "%s"
+  severity   = "Medium"
+
+  condition {
+    measurement  = "timeToBurnEntireBudget"
+    value_string = "1h"
+    lasts_for	   = "300s"
+  }
+
+  condition {
+    measurement  = "timeToBurnEntireBudget"
+    value_string = "1h"
+  }
+}
+`, name, name, testProject)
 }


### PR DESCRIPTION
Motivation
---
Failing tests on [CI](https://g.codefresh.io/build/64c25478f537ed315a417c41?step=test&tab=output&logs=terminal) :
![image](https://github.com/nobl9/terraform-provider-nobl9/assets/69146118/7021507c-4767-49f7-8ac9-90e00af8c86a)

Summary
---
Some time ago we decreased the limit of the alert policy conditions to 3. I had to create new alert policy just with new measurement.

Testing
---
https://g.codefresh.io/build/64c270e7f45bfa93129f5b30?step=test&tab=output&logs=terminal