### PR TITLE
Change `time_to_burn_entire_budget` operator to lte

### DIFF
--- a/nobl9/resource_alert_policy.go
+++ b/nobl9/resource_alert_policy.go
@@ -170,8 +170,10 @@ func marshalAlertConditions(d *schema.ResourceData) []n9api.AlertCondition {
 
 		measurement := condition["measurement"].(string)
 		op := "gte"
-		if measurement == "timeToBurnBudget" || measurement == "timeToBurnEntireBudget" {
+		if measurement == "timeToBurnBudget" {
 			op = "lt"
+		} else if measurement == "timeToBurnEntireBudget" {
+			op = "lte"
 		}
 
 		resultConditions[i] = n9api.AlertCondition{


### PR DESCRIPTION
A recent PR to nobl9-go (https://github.com/nobl9/nobl9-go/pull/89) changed the required operator for `time_to_burn_entire_budget` to `lte` (from `lt`). 
This PR reflects that change in the provider.