### PR TITLE
PC-10771 AWS cross-account observability support

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -269,6 +269,7 @@ Required:
 
 Optional:
 
+- `account_id` (String) AccountID used with cross-account observability feature
 - `dimensions` (Block Set, Max: 10) Set of name/value pairs that is a part of the identity of a metric (see [below for nested schema](#nestedblock--objective--count_metrics--good--cloudwatch--dimensions))
 - `json` (String) JSON query
 - `metric_name` (String) Metric name
@@ -566,6 +567,7 @@ Required:
 
 Optional:
 
+- `account_id` (String) AccountID used with cross-account observability feature
 - `dimensions` (Block Set, Max: 10) Set of name/value pairs that is a part of the identity of a metric (see [below for nested schema](#nestedblock--objective--count_metrics--total--cloudwatch--dimensions))
 - `json` (String) JSON query
 - `metric_name` (String) Metric name
@@ -871,6 +873,7 @@ Required:
 
 Optional:
 
+- `account_id` (String) AccountID used with cross-account observability feature
 - `dimensions` (Block Set, Max: 10) Set of name/value pairs that is a part of the identity of a metric (see [below for nested schema](#nestedblock--objective--raw_metric--query--cloudwatch--dimensions))
 - `json` (String) JSON query
 - `metric_name` (String) Metric name

--- a/nobl9/resource_agent_test.go
+++ b/nobl9/resource_agent_test.go
@@ -126,6 +126,32 @@ resource "nobl9_agent" "%s" {
 `, name, name, testProject)
 }
 
+func testCloudWatchDirectBeta(name string) string {
+	return fmt.Sprintf(`
+resource "nobl9_direct_cloudwatch" "%s" {
+  name      = "%s"
+  project   = "%s"
+  source_of = ["Metrics", "Services"]
+  release_channel = "beta"
+  role_arn = "test"
+  historical_data_retrieval {
+   default_duration {
+	  unit  = "Day"
+	  value = 0
+	}
+	max_duration {
+	  unit  = "Day"
+	  value = 15
+	}
+  }
+  query_delay {
+    unit = "Minute"
+    value = 6
+  }
+}
+`, name, name, testProject)
+}
+
 func testDatadogAgent(name string) string {
 	return fmt.Sprintf(`
 resource "nobl9_agent" "%s" {


### PR DESCRIPTION
Add optional `account_id` field for cloudwatch metrics.