### PR TITLE
fix: Set UserAgent

### DIFF
--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -2,6 +2,7 @@ package nobl9
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sync"
 
@@ -179,6 +180,7 @@ func getClient(providerConfig ProviderConfig) (*sdk.Client, diag.Diagnostics) {
 		if err != nil {
 			panic(err)
 		}
+		sharedClient.SetUserAgent(fmt.Sprintf("terraform-%s", Version))
 	})
 	return sharedClient, diags
 }


### PR DESCRIPTION
With the turmoil over SDK changes in the past months, we've missed UserAgent from `sdk.Client` setup.
This PR brings it back.