### PR TITLE
chore: Remove toolchain declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/nobl9/terraform-provider-nobl9
 
 go 1.21
 
-toolchain go1.21.5
-
 require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320


### PR DESCRIPTION
## Motivation

Remove `toolchain` declaration which was added by mistake in https://github.com/nobl9/terraform-provider-nobl9/commit/5e7b359c4eee60bdf4d69f105d5c3148be951a10.