### PR TITLE
chore: Add release candidate workflow

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,11 @@
+name: Release candidate
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+jobs:
+  test:
+    uses: ./.github/workflows/acc-tests.yml
+    with:
+      clientId: "${{ vars.TERRAFORM_NOBL9_CLIENT_ID }}"
+      clientSecret: "${{ secrets.TERRAFORM_NOBL9_CLIENT_SECRET }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,13 @@
 # You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
-name: release
+name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-beta"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

In order to mimic the release flow of sloctl we should be able to create release candidate which would not be pushed to Terraform registry but would still trigger acceptance tests.