### PR TITLE
chore: Fix release workflow

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -8,4 +8,6 @@ jobs:
     uses: ./.github/workflows/acc-tests.yml
     with:
       clientId: "${{ vars.TERRAFORM_NOBL9_CLIENT_ID }}"
+      project: ${{ vars.TERRAFORM_NOBL9_PROJECT }}
+    secrets:
       clientSecret: "${{ secrets.TERRAFORM_NOBL9_CLIENT_SECRET }}"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -8,6 +8,6 @@ jobs:
     uses: ./.github/workflows/acc-tests.yml
     with:
       clientId: "${{ vars.TERRAFORM_NOBL9_CLIENT_ID }}"
-      project: ${{ vars.TERRAFORM_NOBL9_PROJECT }}
+      project: "${{ vars.TERRAFORM_NOBL9_PROJECT }}"
     secrets:
       clientSecret: "${{ secrets.TERRAFORM_NOBL9_CLIENT_SECRET }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/acc-tests.yml
     with:
       clientId: "${{ vars.TERRAFORM_NOBL9_CLIENT_ID }}"
-      project: ${{ vars.TERRAFORM_NOBL9_PROJECT }}
+      project: "${{ vars.TERRAFORM_NOBL9_PROJECT }}"
     secrets:
       clientSecret: "${{ secrets.TERRAFORM_NOBL9_CLIENT_SECRET }}"
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,16 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-beta"
       - "v[0-9]+.[0-9]+.[0-9]+-alpha"
 jobs:
+  test:
+    uses: ./.github/workflows/acc-tests.yml
+    with:
+      clientId: "${{ vars.TERRAFORM_NOBL9_CLIENT_ID }}"
+      project: ${{ vars.TERRAFORM_NOBL9_PROJECT }}
+    secrets:
+      clientSecret: "${{ secrets.TERRAFORM_NOBL9_CLIENT_SECRET }}"
   goreleaser:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -37,12 +45,6 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: setup github
         run: git config --global url."https://n9-machine-user:${{ secrets.GH_TOKEN }}@github.com".insteadOf "https://github.com"
-      - name: Run acceptance tests
-        uses: ./.github/workflows/acc-tests.yml
-        with:
-          clientId: ${{ vars.TERRAFORM_NOBL9_CLIENT_ID }}
-          clientSecret: ${{ secrets.TERRAFORM_NOBL9_CLIENT_SECRET }}
-          project: ${{ vars.TERRAFORM_NOBL9_PROJECT }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:


### PR DESCRIPTION
## Motivation

Turns out reusable workflow cannot be called from the step level but instead must be be called from job level.