### PR TITLE
chore: Fix acceptance tests env variable names

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -35,8 +35,8 @@ jobs:
           cache: false
       - name: Run acceptance tests
         env:
-          TERRAFORM_NOBL9_CLIENT_ID: "${{ inputs.clientId }}"
-          TERRAFORM_NOBL9_CLIENT_SECRET: "${{ secrets.clientSecret }}"
+          NOBL9_CLIENT_ID: "${{ inputs.clientId }}"
+          NOBL9_CLIENT_SECRET: "${{ secrets.clientSecret }}"
           TERRAFORM_NOBL9_OKTA_ORG_URL: "${{ inputs.oktaOrgUrl }}"
           TERRAFORM_NOBL9_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
           TERRAFORM_NOBL9_PROJECT: "${{ inputs.project }}"

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -43,7 +43,7 @@ func Provider() *schema.Provider {
 			"client_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_ID", nil),
+				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_ID", ""),
 				Description: "the [Client ID](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.",
 			},
 
@@ -51,7 +51,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_SECRET", nil),
+				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_SECRET", ""),
 				Description: "the [Client Secret](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.",
 			},
 

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -43,7 +43,7 @@ func Provider() *schema.Provider {
 			"client_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_ID", ""),
+				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_ID", nil),
 				Description: "the [Client ID](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.",
 			},
 
@@ -51,7 +51,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_SECRET", ""),
+				DefaultFunc: schema.EnvDefaultFunc("NOBL9_CLIENT_SECRET", nil),
 				Description: "the [Client Secret](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.",
 			},
 


### PR DESCRIPTION
## Motivation

Set empty string instead of nil to "cheat" Terraform into thinking we did provide required variable (even though we didn't).