### PR TITLE
chore: Adjust acceptance tests workflow

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          repository: nobl9/terraform-provider-nobl9
+          ref: main
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## Motivation

When calling this reusable workflow from an external repository it is required to explicitly set the right repository and reference name in order to make sure the terraform-provider-nobl9 is checked out, instead of the calling repository.

Ref: https://github.com/actions/checkout.