### PR TITLE
chore: Fix regex for release candidate pipeline

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -2,7 +2,7 @@ name: Release candidate
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 jobs:
   test:
     uses: ./.github/workflows/acc-tests.yml


### PR DESCRIPTION
## Motivation

Wildcard was missing at the end of tags matching regex.