### PR TITLE
test: fix lightstep direct test

### DIFF
--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -43,10 +43,11 @@ If you want to run the tests manually against a different environment, you can
 run the following command:
 
 ```shell
-TERRAFORM_NOBL9_CLIENT_ID=<client_id> \
-TERRAFORM_NOBL9_CLIENT_SECRET=<client_secret> \
-TERRAFORM_NOBL9_OKTA_URL=https://accounts.nobl9.dev \
-TERRAFORM_NOBL9_OKTA_AUTH=<dev_auth_server> \
+NOBL9_CLIENT_ID=<client_id> \
+NOBL9_CLIENT_SECRET=<client_secret> \
+NOBL9_OKTA_URL=https://accounts.nobl9.dev \
+NOBL9_OKTA_AUTH=<dev_auth_server> \
+NOBL9_URL=<ingest_server_url> \
 make test/acc
 ```
 

--- a/nobl9/resource_agent_test.go
+++ b/nobl9/resource_agent_test.go
@@ -376,7 +376,7 @@ resource "nobl9_agent" "%s" {
   lightstep_config {
     organization = "acme"
     project		 = "project1"
-	url			 = "https://api.lightstep.com"
+    url			 = "https://api.lightstep.com"
   }
   release_channel = "beta"
   query_delay {

--- a/nobl9/resource_direct_test.go
+++ b/nobl9/resource_direct_test.go
@@ -301,7 +301,7 @@ resource "nobl9_direct_%s" "%s" {
   description = "desc"
   lightstep_organization = "acme"
   lightstep_project = "project1"
-  lightstep_url = "https://api.lightstep.com"
+  url = "https://api.lightstep.com"
   app_token = "secret"
   historical_data_retrieval {
     default_duration  {


### PR DESCRIPTION
## Motivation

Acceptance tests are failing.

## Summary

Lightstep direct tests were using an invalid field name. This PR solves this issue.
I also updated development docs since the environment variables provided there didn't work.
![image](https://github.com/nobl9/terraform-provider-nobl9/assets/19819643/36e18014-6db6-4361-b9fa-46dbd588396b)
![image](https://github.com/nobl9/terraform-provider-nobl9/assets/19819643/1684cdfe-d28c-4503-a46c-826731d74c65)


## Related Changes

https://github.com/nobl9/terraform-provider-nobl9/commit/2e199e5aaf3a502f9a0610aab1cc92d7a890d888
