### PR TITLE
fix: Default values for alert policy empty `cooldown` and `lasts_for` to be backward compatible

### DIFF
--- a/.github/workflows/acc-tests-dispatch.yml
+++ b/.github/workflows/acc-tests-dispatch.yml
@@ -10,11 +10,6 @@ on:
         description: Client secret to use for authentication
         type: string
         required: true
-      ref:
-        description: Reference branch, tag or commit SHA to checkout
-        required: true
-        type: string
-        default: main
       oktaOrgUrl:
         description: Okta organization URL
         required: false
@@ -33,7 +28,7 @@ jobs:
     uses: ./.github/workflows/acc-tests.yml
     with:
       clientId: "${{ inputs.clientId }}"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref_name }}"
       oktaOrgUrl: "${{ inputs.oktaOrgUrl }}"
       oktaAuthServer: "${{ inputs.oktaAuthServer }}"
       project: "${{ inputs.project }}"

--- a/.github/workflows/acc-tests-dispatch.yml
+++ b/.github/workflows/acc-tests-dispatch.yml
@@ -1,0 +1,41 @@
+name: Acceptance tests dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      clientId:
+        description: Client ID to use for authentication
+        required: true
+        type: string
+      clientSecret:
+        description: Client secret to use for authentication
+        type: string
+        required: true
+      ref:
+        description: Reference branch, tag or commit SHA to checkout
+        required: true
+        type: string
+        default: main
+      oktaOrgUrl:
+        description: Okta organization URL
+        required: false
+        type: string
+      oktaAuthServer:
+        description: Okta authentication server identifier
+        required: false
+        type: string
+      project:
+        description: Project name to create the tested objects in
+        required: false
+        type: string
+        default: default
+jobs:
+  test:
+    uses: ./.github/workflows/acc-tests.yml
+    with:
+      clientId: "${{ inputs.clientId }}"
+      ref: "${{ inputs.ref }}"
+      oktaOrgUrl: "${{ inputs.oktaOrgUrl }}"
+      oktaAuthServer: "${{ inputs.oktaAuthServer }}"
+      project: "${{ inputs.project }}"
+    secrets:
+      clientSecret: "${{ inputs.clientSecret }}"

--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -32,7 +32,8 @@ and makes local debugging easier.
 
 Terraform Provider is mainly tested with acceptance tests, which are plain Go
 tests run with an overlay of Terraform SDK orchestration.
-You can run them with `make test/acc` (recommended).
+You can run them with `make test/acc` (recommended) or from GitHub by dispatching
+[this workflow](https://github.com/nobl9/terraform-provider-nobl9/actions/workflows/acc-tests-dispatch.yml).
 More on acceptance tests can be found
 [here](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests).
 

--- a/nobl9/resource_alert_policy.go
+++ b/nobl9/resource_alert_policy.go
@@ -27,6 +27,7 @@ func resourceAlertPolicy() *schema.Resource {
 			"cooldown": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "5m",
 				//nolint:lll
 				Description: "An interval measured from the last time stamp when all alert policy conditions were satisfied before alert is marked as resolved",
 			},
@@ -189,11 +190,18 @@ func marshalAlertConditions(d *schema.ResourceData) []v1alphaAlertPolicy.AlertCo
 			op = "lte"
 		}
 
+		lastsFor := condition["lasts_for"].(string)
+		alertingWindow := condition["alerting_window"].(string)
+
+		if lastsFor == "" && alertingWindow == "" {
+			lastsFor = "0m"
+		}
+
 		resultConditions[i] = v1alphaAlertPolicy.AlertCondition{
 			Measurement:      measurement,
 			Value:            value,
-			LastsForDuration: condition["lasts_for"].(string),
-			AlertingWindow:   condition["alerting_window"].(string),
+			LastsForDuration: lastsFor,
+			AlertingWindow:   alertingWindow,
 			Operator:         op,
 		}
 	}


### PR DESCRIPTION
## Motivation

ACC tests are failing because detecting changes in `lasts_for` (that was previously set to default 5m when not defined) and cooldown (that is new in Terraform) 

https://github.com/nobl9/n9/actions/runs/8169474253/job/22338158247

## Summary

Repeat logic that is implemented in Ingest:
- When cooldown is not defined, default 5m cooldown is set - which is aligned with our API, no diff with existing alert policies should be detected.
- When none of `lasts_for` or `alerting_window` is configured, then we can assume that `lasts_for=0m`. However, we cannot use default '0m' for this field because API would return validation error when user wants to set `alerting_window`. 

## Related Changes

- https://github.com/nobl9/terraform-provider-nobl9/pull/177

## Testing

- https://github.com/nobl9/terraform-provider-nobl9/actions/runs/8179122240
![image](https://github.com/nobl9/terraform-provider-nobl9/assets/69146118/6984ead1-1c20-4d44-9050-42516e795f02)

Manually:
1. `nano main.tf`
2. `rm .terraform.lock.hcl && make install && terraform init -upgrade && terraform apply`

```tf
terraform {
  required_providers {
    nobl9 = {
      source = "nobl9.com/nobl9/nobl9"
      version = "0.24.0"
    }
  }
}

provider "nobl9" {
  client_id = "<CLIENT_ID>"
  client_secret = "<CLIENT_SECRET>"
  ingest_url       = "https://dev-demo-3.nobl9.dev/api"
  okta_org_url     = "https://accounts.nobl9.dev"
  okta_auth_server = "ausdh506kj9JJVw3g4x6"
}

resource "nobl9_project" "test" {
  name = "test"
}

resource "nobl9_service" "test" {
  name    = "test"
  project = "test"
}

resource "nobl9_alert_policy" "alert_policy_1" {
  name         = "alert-policy-1"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
  }
}

resource "nobl9_alert_policy" "alert_policy_2" {
  name         = "alert-policy-2"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    lasts_for = "5m"
  }
}

resource "nobl9_alert_policy" "alert_policy_3" {
  name         = "alert-policy-3"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    lasts_for = "0m"
  }
}

resource "nobl9_alert_policy" "alert_policy_4" {
  name         = "alert-policy-4"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    alerting_window = "10m"
  }
}
```

I tested also different scenario that can happen. I applied two times each terraform file to confirm that no diff is detected and operation is allowed (like switching from lasts_for to alerting_window and that default 0m won't make any diff..

```tf
resource "nobl9_alert_policy" "alert_policy_existing" {
  name         = "alert-policy-existing"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    // previously lasts_for was set to default 0m
  }
}
```

```tf
resource "nobl9_alert_policy" "alert_policy_existing" {
  name         = "alert-policy-existing"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    lasts_for = "0m"
  }
}
```

```tf
resource "nobl9_alert_policy" "alert_policy_existing" {
  name         = "alert-policy-existing"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    lasts_for = "5m"
  }
}
```

```tf
resource "nobl9_alert_policy" "alert_policy_existing" {
  name         = "alert-policy-existing"
  project      = "test"
  severity     = "High"

  condition {
    measurement  = "averageBurnRate"
    value = "20"
    alerting_window = "10m"
  }
}
```