### PR TITLE
chore: Fix goreleaser marking pre-releases as latest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  make_latest: false
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'


### PR DESCRIPTION
## Related Changes

https://github.com/nobl9/sloctl/pull/103