### PR TITLE
PC-12653+PC-12085 feat: Allow to set mathematical operator for burnedBudget alerting condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ NAMESPACE=nobl9
 NAME=nobl9
 BIN_DIR=./bin
 BINARY=$(BIN_DIR)/terraform-provider-$(NAME)
-VERSION=0.25.0
+VERSION=0.26.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
-OS_ARCH?=linux_amd64
+OS_ARCH?=darwin_arm64
 
 # renovate datasource=github-releases depName=securego/gosec
 GOSEC_VERSION := v2.19.0

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAMESPACE=nobl9
 NAME=nobl9
 BIN_DIR=./bin
 BINARY=$(BIN_DIR)/terraform-provider-$(NAME)
-VERSION=0.26.0
+VERSION=0.25.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=darwin_arm64
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BIN_DIR=./bin
 BINARY=$(BIN_DIR)/terraform-provider-$(NAME)
 VERSION=0.25.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
-OS_ARCH?=darwin_arm64
+OS_ARCH?=linux_amd64
 
 # renovate datasource=github-releases depName=securego/gosec
 GOSEC_VERSION := v2.19.0

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -30,58 +30,204 @@ resource "nobl9_service" "this" {
   description  = "Front page service"
 }
 
-resource "nobl9_alert_policy" "this" {
-  name         = "${nobl9_project.this.name}-front-page-latency"
+# Alert when a high momentary burn rate risks exhausting the budget (any time window).
+resource "nobl9_alert_policy" "fast_burn_20x_over_5m" {
+  name         = "fast-burn-20x5min"
   project      = nobl9_project.this.name
-  display_name = "${nobl9_project.this.display_name} Front Page Latency"
-  severity     = "High"
-  description  = "Alert when page latency is > 2000 and error budget would be exhausted"
-  cooldown     = "5m"
-
-  condition {
-    measurement  = "timeToBurnBudget"
-    value_string = "72h"
-    lasts_for    = "30m"
-  }
-
-  alert_method {
-    name = "my-alert-method"
-  }
-}
-
-resource "nobl9_alert_policy" "this" {
-  name         = "${nobl9_project.this.name}-slow-burn"
-  project      = nobl9_project.this.name
-  display_name = "${nobl9_project.this.display_name} Slow Burn (1x12h and 2x15min)"
-  severity     = "Low"
-  description  = "The budget is slowly exhausting and not recovering."
-  cooldown     = "5m"
-
-  condition {
-    measurement     = "averageBurnRate"
-    value           = "1"
-    alerting_window = "12h"
-  }
-
-  condition {
-    measurement     = "averageBurnRate"
-    value           = "2"
-    alerting_window = "15m"
-  }
-}
-
-resource "nobl9_alert_policy" "this" {
-  name         = "${nobl9_project.this.name}-fast-burn"
-  project      = nobl9_project.this.name
-  display_name = "${nobl9_project.this.display_name} Fast Burn (20x5min)"
+  display_name = "${nobl9_project.this.display_name} Fast burn (20x5min)"
   severity     = "High"
   description  = "There’s been a significant spike in burn rate over a brief period."
   cooldown     = "5m"
 
   condition {
     measurement     = "averageBurnRate"
-    value           = "20"
+    value           = 20.0
     alerting_window = "5m"
+    op              = "gte"
+  }
+}
+
+# Alert when the budget burns slowly, and is not recovering (time windows over a week)
+resource "nobl9_alert_policy" "slow_burn_1x_over_2d_and_2x_over_15m" {
+  name         = "slow-burn-1x2d-and-2x15min"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow burn (1x2d and 2x15min)"
+  severity     = "Low"
+  description  = "The budget is slowly being exhausted and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 1.0
+    alerting_window = "48h"
+    op              = "gte"
+  }
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 2.0
+    alerting_window = "15m"
+    op              = "gte"
+  }
+}
+
+# Alert when the budget burns slowly and is not recovering (time windows up to one week)
+resource "nobl9_alert_policy" "slow_burn_1x_over_12h_and_2x_over_15m" {
+  name         = "slow-burn-1x12h-and-2x15min"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow burn (1x12h and 2x15min)"
+  severity     = "Low"
+  description  = "The budget is slowly exhausting and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 1.0
+    alerting_window = "12h"
+  }
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 2.0
+    alerting_window = "15m"
+  }
+}
+
+# Alert when the error budget is nearly exhausted (any time window)
+resource "nobl9_alert_policy" "budget_almost_exhausted" {
+  name         = "budget-almost-exhausted"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Budget almost exhausted (20%)"
+  severity     = "High"
+  description  = "The error budget is nearly exhausted (20% left)."
+  cooldown     = "5m"
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 0.8
+    op          = "gte"
+  }
+}
+
+# There is no budget left and entire budget would be exhausted in 8h and this condition lasts for 15m.
+resource "nobl9_alert_policy" "entire_exhaustion_prediction_8h_lasts_for" {
+  name         = "entire-exhaustion-prediction-8h-lasts-for"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Entire budget exhaustion in 8h"
+  severity     = "Low"
+  description  = "No error budget left, but entire error budget would be exhausted in 8h."
+  cooldown     = "15m"
+
+  condition {
+    measurement  = "timeToBurnEntireBudget"
+    value_string = "8h"
+    lasts_for    = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "gte"
+  }
+}
+
+# There is still some budget and remaining budget will be exhausted in 3 days.
+resource "nobl9_alert_policy" "remaining_exhaustion_prediction_3d_lasts_for" {
+  name         = "remaining-exhaustion-prediction-3d-lasts-for"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Remaining budget exhaustion in 3d"
+  severity     = "Low"
+  description  = "Remaining budget will be exhausted in 3 days."
+  cooldown     = "15m"
+
+  condition {
+    measurement  = "timeToBurnBudget"
+    value_string = "72h"
+    lasts_for    = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "lt"
+  }
+}
+
+# Fast exhaustion below budget
+resource "nobl9_alert_policy" "fast_exhaustion_bewlo_budget_alerting_window" {
+  name         = "fast-exhaustion-below-budget-alerting-window"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Fast exhaustion below budget (3d)"
+  severity     = "High"
+  description  = "The error budget is exhausting significantly, and there’s no remaining budget left."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "timeToBurnEntireBudget"
+    value_string    = "72h"
+    alerting_window = "10m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "gte"
+  }
+}
+
+# There is still some budget, slow exhaustion for long window SLOs
+resource "nobl9_alert_policy" "slow_exhaustion_for_long_time_window_alerting_window" {
+  name         = "slow-exhaustion-for-long-time-window-alerting-window"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow exhaustion (20d)"
+  severity     = "Low"
+  description  = "The error budget is above 0% is exhausting slowly and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "480h"
+    alerting_window = "48h"
+  }
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "480h"
+    alerting_window = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "lt"
+  }
+}
+
+# There is still some budget, slow exhaustion for short window SLOs
+resource "nobl9_alert_policy" "slow_exhaustion_for_short_time_window_alerting_window" {
+  name         = "slow-exhaustion-for-short-time-window-alerting-window"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow exhaustion (5d)"
+  severity     = "Low"
+  description  = "The error budget is above 0% and is exhausting slowly and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "120h"
+    alerting_window = "12h"
+  }
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "120h"
+    alerting_window = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "lt"
   }
 }
 ```

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -118,6 +118,7 @@ Optional:
 
 - `alerting_window` (String) Duration over which the burn rate is evaluated.
 - `lasts_for` (String) Indicates how long a given condition needs to be valid to mark the condition as true.
+- `op` (String) A mathematical inequality operator. One of `lt` | `lte` | `gt` | `gte`.
 - `value` (Number) For `averageBurnRate`, it indicates how fast the error budget is burning. For `burnedBudget`, it tells how much error budget is already burned.
 - `value_string` (String) Used with `timeToBurnBudget` or `timeToBurnEntireBudget`, indicates when the budget would be exhausted. The expected value is a string in time duration string format.
 

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -154,7 +154,7 @@ resource "nobl9_alert_policy" "remaining_exhaustion_prediction_3d_lasts_for" {
 }
 
 # Fast exhaustion below budget
-resource "nobl9_alert_policy" "fast_exhaustion_bewlo_budget_alerting_window" {
+resource "nobl9_alert_policy" "fast_exhaustion_below_budget_alerting_window" {
   name         = "fast-exhaustion-below-budget-alerting-window"
   project      = nobl9_project.this.name
   display_name = "${nobl9_project.this.display_name} Fast exhaustion below budget (3d)"

--- a/examples/resources/nobl9_alert_policy/resource.tf
+++ b/examples/resources/nobl9_alert_policy/resource.tf
@@ -135,7 +135,7 @@ resource "nobl9_alert_policy" "remaining_exhaustion_prediction_3d_lasts_for" {
 }
 
 # Fast exhaustion below budget
-resource "nobl9_alert_policy" "fast_exhaustion_bewlo_budget_alerting_window" {
+resource "nobl9_alert_policy" "fast_exhaustion_below_budget_alerting_window" {
   name         = "fast-exhaustion-below-budget-alerting-window"
   project      = nobl9_project.this.name
   display_name = "${nobl9_project.this.display_name} Fast exhaustion below budget (3d)"

--- a/examples/resources/nobl9_alert_policy/resource.tf
+++ b/examples/resources/nobl9_alert_policy/resource.tf
@@ -11,57 +11,203 @@ resource "nobl9_service" "this" {
   description  = "Front page service"
 }
 
-resource "nobl9_alert_policy" "this" {
-  name         = "${nobl9_project.this.name}-front-page-latency"
+# Alert when a high momentary burn rate risks exhausting the budget (any time window).
+resource "nobl9_alert_policy" "fast_burn_20x_over_5m" {
+  name         = "fast-burn-20x5min"
   project      = nobl9_project.this.name
-  display_name = "${nobl9_project.this.display_name} Front Page Latency"
-  severity     = "High"
-  description  = "Alert when page latency is > 2000 and error budget would be exhausted"
-  cooldown     = "5m"
-
-  condition {
-    measurement  = "timeToBurnBudget"
-    value_string = "72h"
-    lasts_for    = "30m"
-  }
-
-  alert_method {
-    name = "my-alert-method"
-  }
-}
-
-resource "nobl9_alert_policy" "this" {
-  name         = "${nobl9_project.this.name}-slow-burn"
-  project      = nobl9_project.this.name
-  display_name = "${nobl9_project.this.display_name} Slow Burn (1x12h and 2x15min)"
-  severity     = "Low"
-  description  = "The budget is slowly exhausting and not recovering."
-  cooldown     = "5m"
-
-  condition {
-    measurement     = "averageBurnRate"
-    value           = "1"
-    alerting_window = "12h"
-  }
-
-  condition {
-    measurement     = "averageBurnRate"
-    value           = "2"
-    alerting_window = "15m"
-  }
-}
-
-resource "nobl9_alert_policy" "this" {
-  name         = "${nobl9_project.this.name}-fast-burn"
-  project      = nobl9_project.this.name
-  display_name = "${nobl9_project.this.display_name} Fast Burn (20x5min)"
+  display_name = "${nobl9_project.this.display_name} Fast burn (20x5min)"
   severity     = "High"
   description  = "There’s been a significant spike in burn rate over a brief period."
   cooldown     = "5m"
 
   condition {
     measurement     = "averageBurnRate"
-    value           = "20"
+    value           = 20.0
     alerting_window = "5m"
+    op              = "gte"
+  }
+}
+
+# Alert when the budget burns slowly, and is not recovering (time windows over a week)
+resource "nobl9_alert_policy" "slow_burn_1x_over_2d_and_2x_over_15m" {
+  name         = "slow-burn-1x2d-and-2x15min"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow burn (1x2d and 2x15min)"
+  severity     = "Low"
+  description  = "The budget is slowly being exhausted and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 1.0
+    alerting_window = "48h"
+    op              = "gte"
+  }
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 2.0
+    alerting_window = "15m"
+    op              = "gte"
+  }
+}
+
+# Alert when the budget burns slowly and is not recovering (time windows up to one week)
+resource "nobl9_alert_policy" "slow_burn_1x_over_12h_and_2x_over_15m" {
+  name         = "slow-burn-1x12h-and-2x15min"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow burn (1x12h and 2x15min)"
+  severity     = "Low"
+  description  = "The budget is slowly exhausting and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 1.0
+    alerting_window = "12h"
+  }
+
+  condition {
+    measurement     = "averageBurnRate"
+    value           = 2.0
+    alerting_window = "15m"
+  }
+}
+
+# Alert when the error budget is nearly exhausted (any time window)
+resource "nobl9_alert_policy" "budget_almost_exhausted" {
+  name         = "budget-almost-exhausted"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Budget almost exhausted (20%)"
+  severity     = "High"
+  description  = "The error budget is nearly exhausted (20% left)."
+  cooldown     = "5m"
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 0.8
+    op          = "gte"
+  }
+}
+
+# There is no budget left and entire budget would be exhausted in 8h and this condition lasts for 15m.
+resource "nobl9_alert_policy" "entire_exhaustion_prediction_8h_lasts_for" {
+  name         = "entire-exhaustion-prediction-8h-lasts-for"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Entire budget exhaustion in 8h"
+  severity     = "Low"
+  description  = "No error budget left, but entire error budget would be exhausted in 8h."
+  cooldown     = "15m"
+
+  condition {
+    measurement  = "timeToBurnEntireBudget"
+    value_string = "8h"
+    lasts_for    = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "gte"
+  }
+}
+
+# There is still some budget and remaining budget will be exhausted in 3 days.
+resource "nobl9_alert_policy" "remaining_exhaustion_prediction_3d_lasts_for" {
+  name         = "remaining-exhaustion-prediction-3d-lasts-for"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Remaining budget exhaustion in 3d"
+  severity     = "Low"
+  description  = "Remaining budget will be exhausted in 3 days."
+  cooldown     = "15m"
+
+  condition {
+    measurement  = "timeToBurnBudget"
+    value_string = "72h"
+    lasts_for    = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "lt"
+  }
+}
+
+# Fast exhaustion below budget
+resource "nobl9_alert_policy" "fast_exhaustion_bewlo_budget_alerting_window" {
+  name         = "fast-exhaustion-below-budget-alerting-window"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Fast exhaustion below budget (3d)"
+  severity     = "High"
+  description  = "The error budget is exhausting significantly, and there’s no remaining budget left."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "timeToBurnEntireBudget"
+    value_string    = "72h"
+    alerting_window = "10m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "gte"
+  }
+}
+
+# There is still some budget, slow exhaustion for long window SLOs
+resource "nobl9_alert_policy" "slow_exhaustion_for_long_time_window_alerting_window" {
+  name         = "slow-exhaustion-for-long-time-window-alerting-window"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow exhaustion (20d)"
+  severity     = "Low"
+  description  = "The error budget is above 0% is exhausting slowly and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "480h"
+    alerting_window = "48h"
+  }
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "480h"
+    alerting_window = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "lt"
+  }
+}
+
+# There is still some budget, slow exhaustion for short window SLOs
+resource "nobl9_alert_policy" "slow_exhaustion_for_short_time_window_alerting_window" {
+  name         = "slow-exhaustion-for-short-time-window-alerting-window"
+  project      = nobl9_project.this.name
+  display_name = "${nobl9_project.this.display_name} Slow exhaustion (5d)"
+  severity     = "Low"
+  description  = "The error budget is above 0% and is exhausting slowly and not recovering."
+  cooldown     = "5m"
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "120h"
+    alerting_window = "12h"
+  }
+
+  condition {
+    measurement     = "timeToBurnBudget"
+    value_string    = "120h"
+    alerting_window = "15m"
+  }
+
+  condition {
+    measurement = "burnedBudget"
+    value       = 1.0
+    op          = "lt"
   }
 }

--- a/nobl9/resource_alert_policy.go
+++ b/nobl9/resource_alert_policy.go
@@ -187,12 +187,7 @@ func marshalAlertConditions(d *schema.ResourceData) []v1alphaAlertPolicy.AlertCo
 		}
 
 		measurement := condition["measurement"].(string)
-		op := "gte"
-		if measurement == "timeToBurnBudget" {
-			op = "lt"
-		} else if measurement == "timeToBurnEntireBudget" {
-			op = "lte"
-		}
+		op := defaultOperatorForMeasurement(measurement)
 
 		lastsFor := condition["lasts_for"].(string)
 		alertingWindow := condition["alerting_window"].(string)
@@ -347,4 +342,18 @@ func resourceAlertPolicyDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 	return nil
+}
+
+func defaultOperatorForMeasurement(measurement string) string {
+	switch measurement {
+	case "timeToBurnBudget":
+		return "lt"
+	case "timeToBurnEntireBudget":
+		return "lte"
+	case "burnedBudget", "averageBurnRate":
+		return "gte"
+	default:
+		// Unknown measurement, so let API to decide what to do.
+		return ""
+	}
 }

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -312,8 +312,8 @@ func TestAcc_Nobl9AlertPolicy(t *testing.T) {
 		},
 	} {
 		t.Run(scenario, func(t *testing.T) {
-			resourceName := strings.Replace(scenario, " ", "_", -1)
-			alertPolicyName := strings.Replace(scenario, " ", "-", -1)
+			resourceName := strings.ReplaceAll(scenario, " ", "_")
+			alertPolicyName := strings.ReplaceAll(scenario, " ", "-")
 
 			res := alertPolicyConfig.Build(resourceName, alertPolicyName, testProject)
 

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -12,18 +12,6 @@ import (
 )
 
 func TestAcc_Nobl9AlertPolicy(t *testing.T) {
-	alertMethodsRes := func() string {
-		return fmt.Sprintf(`
-%s
-%s
-%s
-`,
-			alertMethodConfig("am1", "am1", testProject),
-			alertMethodConfig("am2", "am2", testProject),
-			alertMethodConfig("am3", "am3", testProject),
-		)
-	}
-
 	for scenario, alertPolicyConfig := range map[string]alertPolicyConfig{
 		// Test optional description.
 		"alert policy with no description": {
@@ -49,221 +37,267 @@ func TestAcc_Nobl9AlertPolicy(t *testing.T) {
 		// Test multiple conditions order.
 		"alert policy with multiple conditions": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 0.9
-			}
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 0.9
+				}
 
-			condition {
-				measurement	= "averageBurnRate"
-				value 	  	= 3
-				lasts_for	= "1m"
-			}
+				condition {
+					measurement	= "averageBurnRate"
+					value 	  	= 3
+					lasts_for	= "1m"
+				}
 
-			condition {
-				measurement  = "timeToBurnBudget"
-				value_string = "1h"
-				lasts_for	 = "300s"
-			}`,
+				condition {
+					measurement  = "timeToBurnBudget"
+					value_string = "1h"
+					lasts_for	 = "300s"
+				}`,
 		},
 		"alert policy with multiple conditions reversed": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement  = "timeToBurnBudget"
-				value_string = "1h"
-				lasts_for	 = "300s"
-			}
+				condition {
+					measurement  = "timeToBurnBudget"
+					value_string = "1h"
+					lasts_for	 = "300s"
+				}
 
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 0.9
-			}
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 0.9
+				}
 
-			condition {
-				measurement = "averageBurnRate"
-				value 	  	= 3
-				lasts_for	= "1m"
-			}`,
+				condition {
+					measurement = "averageBurnRate"
+					value 	  	= 3
+					lasts_for	= "1m"
+				}`,
 		},
 		// Test alert methods
 		"alert policy with no alert method": {
 			OverrideAlertMethodsBlock: ``,
 		},
 		"alert policy with multiple alert method": {
-			AdditionalResources: alertMethodsRes(),
+			AdditionalResources: fmt.Sprintf(`
+			resource "nobl9_alert_method_slack" "%s" {
+				name        = "%s"
+				project     = "%s"
+				description = "slack"
+				url         = "https://slack.com"
+			}
+			resource "nobl9_alert_method_slack" "%s" {
+				name        = "%s"
+				project     = "%s"
+				description = "slack"
+				url         = "https://slack.com"
+			}
+			resource "nobl9_alert_method_slack" "%s" {
+				name        = "%s"
+				project     = "%s"
+				description = "slack"
+				url         = "https://slack.com"
+			}
+			`,
+				"am1", "am1", testProject,
+				"am2", "am2", testProject,
+				"am3", "am3", testProject,
+			),
 			OverrideAlertMethodsBlock: fmt.Sprintf(`
 			alert_method {
-				name = nobl9_alert_method_slack.am1
-				project = %s
+				name = nobl9_alert_method_slack.am1.name
+				project = "%s"
 			}
 			alert_method {
-				name = nobl9_alert_method_slack.am2
-				project = %s
+				name = nobl9_alert_method_slack.am2.name
+				project = "%s"
 			}
 			alert_method {
-				name = nobl9_alert_method_slack.am3
-				project = %s
+				name = nobl9_alert_method_slack.am3.name
+				project = "%s"
 			}
 			`, testProject, testProject, testProject),
 		},
 		"alert policy with multiple alert method reversed": {
-			AdditionalResources: alertMethodsRes(),
+			AdditionalResources: fmt.Sprintf(`
+			resource "nobl9_alert_method_slack" "%s" {
+				name        = "%s"
+				project     = "%s"
+				description = "slack"
+				url         = "https://slack.com"
+			}
+			resource "nobl9_alert_method_slack" "%s" {
+				name        = "%s"
+				project     = "%s"
+				description = "slack"
+				url         = "https://slack.com"
+			}
+			resource "nobl9_alert_method_slack" "%s" {
+				name        = "%s"
+				project     = "%s"
+				description = "slack"
+				url         = "https://slack.com"
+			}
+			`,
+				"am1", "am1", testProject,
+				"am2", "am2", testProject,
+				"am3", "am3", testProject,
+			),
 			OverrideAlertMethodsBlock: fmt.Sprintf(`
 			alert_method {
-				name = nobl9_alert_method_slack.am3
-				project = %s
+				name = nobl9_alert_method_slack.am3.name
+				project = "%s"
 			}
 			alert_method {
-				name = nobl9_alert_method_slack.am2
-				project = %s
+				name = nobl9_alert_method_slack.am2.name
+				project = "%s"
 			}
 			alert_method {
-				name = nobl9_alert_method_slack.am1
-				project = %s
+				name = nobl9_alert_method_slack.am1.name
+				project = "%s"
 			}
 			`, testProject, testProject, testProject),
 		},
 		// Measurement: burnedBudget
 		"burned budget with default operator and lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 1.0
-			}`,
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 1.0
+				}`,
 		},
 		"burned budget with value 0": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 0.0
-			}`,
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 0.0
+				}`,
 		},
 		"burned budget with explicit default operator": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 1.0
-				op			= "gte"
-			}`,
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 1.0
+					op			= "gte"
+				}`,
 		},
 		"burned budget with custom operator": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 1.0
-				op			= "lt"
-			}`,
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 1.0
+					op			= "lt"
+				}`,
 		},
 		"burned budget with custom lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "burnedBudget"
-				value 	  	= 1.0
-				lasts_for	= "10m"
-			}`,
+				condition {
+					measurement = "burnedBudget"
+					value 	  	= 1.0
+					lasts_for	= "10m"
+				}`,
 		},
 		// Measurement: averageBurnRate
 		"average burn rate with default operator and lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "averageBurnRate"
-				value 	  	= 1.0
-			}`,
+				condition {
+					measurement = "averageBurnRate"
+					value 	  	= 1.0
+				}`,
 		},
 		"average burn rate with value 0": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "averageBurnRate"
-				value 	  	= 0.0
-			}`,
+				condition {
+					measurement = "averageBurnRate"
+					value 	  	= 0.0
+				}`,
 		},
 		"average burn rate with explicit default operator": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "averageBurnRate"
-				value 	  	= 1.0
-				op			= "gte"
-			}`,
+				condition {
+					measurement = "averageBurnRate"
+					value 	  	= 1.0
+					op			= "gte"
+				}`,
 		},
 		"average burn rate with custom lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement = "averageBurnRate"
-				value 	  	= 1.0
-				lasts_for	= "10m"
-			}`,
+				condition {
+					measurement = "averageBurnRate"
+					value 	  	= 1.0
+					lasts_for	= "10m"
+				}`,
 		},
 		"average burn rate with custom alerting window": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "averageBurnRate"
-				value 	  		= 1.0
-				alerting_window	= "10m"
-			}`,
+				condition {
+					measurement 	= "averageBurnRate"
+					value 	  		= 1.0
+					alerting_window	= "10m"
+				}`,
 		},
 		// Measurement: timeToBurnBudget
 		"time to burn budget with default operator and lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnBudget"
-				value_string 	= "6h"
-			}`,
+				condition {
+					measurement 	= "timeToBurnBudget"
+					value_string 	= "6h"
+				}`,
 		},
 		"time to burn budget with explicit default operator": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnBudget"
-				value_string 	= "6h"
-				op				= "lt"
-			}`,
+				condition {
+					measurement 	= "timeToBurnBudget"
+					value_string 	= "6h"
+					op				= "lt"
+				}`,
 		},
 		"time to burn budget with custom lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnBudget"
-				value_string 	= "6h"
-				lasts_for		= "10m"
-			}`,
+				condition {
+					measurement 	= "timeToBurnBudget"
+					value_string 	= "6h"
+					lasts_for		= "10m"
+				}`,
 		},
 		"time to burn budget with custom alerting window": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnBudget"
-				value_string 	= "6h"
-				alerting_window	= "10m"
-			}`,
+				condition {
+					measurement 	= "timeToBurnBudget"
+					value_string 	= "6h"
+					alerting_window	= "10m"
+				}`,
 		},
 		// Measurement: timeToBurnEntireBudget
 		"time to burn entire budget with default operator and lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnEntireBudget"
-				value_string 	= "6h"
-			}`,
+				condition {
+					measurement 	= "timeToBurnEntireBudget"
+					value_string 	= "6h"
+				}`,
 		},
 		"time to burn entire budget with explicit default operator": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnEntireBudget"
-				value_string 	= "6h"
-				op				= "lte"
-			}`,
+				condition {
+					measurement 	= "timeToBurnEntireBudget"
+					value_string 	= "6h"
+					op				= "lte"
+				}`,
 		},
 		"time to burn entire budget with custom lasts for": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnEntireBudget"
-				value_string 	= "6h"
-				lasts_for		= "10m"
-			}`,
+				condition {
+					measurement 	= "timeToBurnEntireBudget"
+					value_string 	= "6h"
+					lasts_for		= "10m"
+				}`,
 		},
 		"time to burn entire budget with custom alerting window": {
 			OverrideConditionsBlock: `
-			condition {
-				measurement 	= "timeToBurnEntireBudget"
-				value_string 	= "6h"
-				alerting_window	= "10m"
-			}`,
+				condition {
+					measurement 	= "timeToBurnEntireBudget"
+					value_string 	= "6h"
+					alerting_window	= "10m"
+				}`,
 		},
 	} {
 		t.Run(scenario, func(t *testing.T) {
@@ -312,6 +346,7 @@ type alertPolicyConfig struct {
 	OverrideDescriptionBlock  string
 	OverrideCooldownBlock     string
 	OverrideConditionsBlock   string
+	OverrideSeverityBlock     string
 	OverrideAlertMethodsBlock string
 	AdditionalResources       string
 }
@@ -332,7 +367,11 @@ resource "nobl9_alert_policy" "%s" {`, ap.AdditionalResources, resourceName))
 	b.WriteString("\n	")
 	b.WriteString(fmt.Sprintf(`project = "%s"`, project))
 	b.WriteString("\n	")
-	b.WriteString(`severity = "Low"`)
+	if ap.OverrideSeverityBlock == "" {
+		b.WriteString(`severity = "Low"`)
+	} else {
+		b.WriteString(ap.OverrideSeverityBlock)
+	}
 	b.WriteString("\n	")
 	if ap.OverrideCooldownBlock != "" {
 		b.WriteString(ap.OverrideCooldownBlock)
@@ -358,15 +397,4 @@ resource "nobl9_alert_policy" "%s" {`, ap.AdditionalResources, resourceName))
 	b.WriteString(`
 }`)
 	return b.String()
-}
-
-func alertMethodConfig(resourceName, name, project string) string {
-	return fmt.Sprintf(`
-resource "nobl9_alert_method_slack" "%s" {
-  name        = "%s"
-  project     = "%s"
-  description = "slack"
-  url         = "https://slack.com"
-}
-`, resourceName, name, project)
 }

--- a/nobl9/resource_slo_test.go
+++ b/nobl9/resource_slo_test.go
@@ -3387,3 +3387,30 @@ resource "nobl9_slo" "%s" {
 }
 `, name, name, serviceName, testProject, agentName, testProject)
 }
+
+func testAlertPolicyWithoutAnyAlertMethod(name string) string {
+	return fmt.Sprintf(`
+resource "nobl9_alert_policy" "%s" {
+  name       = "%s"
+  project    = "%s"
+  severity   = "Medium"
+
+  condition {
+	  measurement = "burnedBudget"
+	  value 	  = 0.9
+	}
+
+  condition {
+	  measurement = "averageBurnRate"
+	  value 	  = 3
+	  lasts_for	  = "1m"
+	}
+
+  condition {
+	  measurement  = "timeToBurnBudget"
+	  value_string = "1h"
+	  lasts_for	   = "300s"
+	}
+}
+`, name, name, testProject)
+}


### PR DESCRIPTION
## Motivation

Allow user to define any valid mathematical operator for `burnedBudget` condition type maintaining backward compatibility (using default operator).

We want also to update examples for Terraform provider that includes new alerting conditions (time to burn budget / time to burn entire budget based on alerting window and configurable mathematical operator for burned budget).

## Summary

When user provide no mathematical operator to avoid false differences use default operator for given measurement type. It requires changes provided in https://github.com/nobl9/nobl9-go/pull/377

Added more ACC tests for alert policy.

## Bonus track

It looks like this example didn't work correctly. I fixed by changing the condition [here](https://github.com/nobl9/terraform-provider-nobl9/blob/15c27dacb13dc01d0b0cdc4c21147462e1fbc270/nobl9/resource_alert_policy.go#L198-L201).
```tf
resource "nobl9_alert_policy" "this" {
  name         = "test"
  project      = nobl9_project.this.name
  severity     = "High"
  cooldown     = "5m"

  condition {
    measurement     = "burnedBudget"
    value           = 0.0
  }
}
```
after re-apply this resource, it shows still a difference:
![image](https://github.com/nobl9/terraform-provider-nobl9/assets/69146118/50af7450-7a12-4bb0-94e5-e6410e4c3b88)

## Testing
1. Locally run ACC tests via:
nano `.env` and run tests with `env $(cat .env) go test ./nobl9 -v`:
```bash
NOBL9_OKTA_URL=
TF_ACC=1
NOBL9_OKTA_AUTH=
NOBL9_CLIENT_ID=
NOBL9_CLIENT_SECRET=
```

2. With GH action: https://github.com/nobl9/terraform-provider-nobl9/actions/runs/8799415494
> --- PASS: TestAcc_Nobl9AlertPolicy (41.83s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_custom_description (1.54s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_no_cooldown_defined (1.34s)
    --- PASS: TestAcc_Nobl9AlertPolicy/burned_budget_with_default_operator_and_lasts_for (1.26s)
    --- PASS: TestAcc_Nobl9AlertPolicy/burned_budget_with_value_0 (1.21s)
    --- PASS: TestAcc_Nobl9AlertPolicy/burned_budget_with_explicit_default_operator (1.23s)
    --- PASS: TestAcc_Nobl9AlertPolicy/burned_budget_with_custom_lasts_for (1.32s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_budget_with_custom_lasts_for (1.28s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_entire_budget_with_custom_lasts_for (1.23s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_no_display_name (1.27s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_custom_display_name (1.28s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_no_alert_method (1.32s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_entire_budget_with_explicit_default_operator (1.37s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_no_annotations (1.28s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_custom_cooldown (1.27s)
    --- PASS: TestAcc_Nobl9AlertPolicy/burned_budget_with_custom_operator (1.26s)
    --- PASS: TestAcc_Nobl9AlertPolicy/average_burn_rate_with_explicit_default_operator (1.25s)
    --- PASS: TestAcc_Nobl9AlertPolicy/average_burn_rate_with_custom_alerting_window (1.26s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_budget_with_explicit_default_operator (1.26s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_entire_budget_with_default_operator_and_lasts_for (1.31s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_entire_budget_with_custom_alerting_window (1.34s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_multiple_alert_method (2.26s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_multiple_alert_method_reversed (2.20s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_annotations (1.28s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_multiple_conditions_reversed (1.29s)
    --- PASS: TestAcc_Nobl9AlertPolicy/average_burn_rate_with_default_operator_and_lasts_for (1.26s)
    --- PASS: TestAcc_Nobl9AlertPolicy/average_burn_rate_with_value_0 (1.23s)
    --- PASS: TestAcc_Nobl9AlertPolicy/average_burn_rate_with_custom_lasts_for (1.35s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_budget_with_default_operator_and_lasts_for (1.25s)
    --- PASS: TestAcc_Nobl9AlertPolicy/time_to_burn_budget_with_custom_alerting_window (1.25s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_no_description (1.25s)
    --- PASS: TestAcc_Nobl9AlertPolicy/alert_policy_with_multiple_conditions (1.34s)

4. Manually with `terraform apply`:
nano `main.tf` and then `rm -rf ~/.terraform.d/plugins/nobl9.com/nobl9/nobl9/0.25.0 && make install && terraform init -upgrade && terraform apply`:
```tf
terraform {
  required_providers {
    nobl9 = {
      source = "nobl9.com/nobl9/nobl9"
      version = "0.25.0"
    }
  }
}

provider "nobl9" {
  client_id = ""
  client_secret = ""
  okta_org_url     = ""
  okta_auth_server = ""
}

# I copied here content of `./examples/resources/nobl9_alert_policy/resource.tf`
```

## Release Notes

Allow user to configure any valid mathematical operator for alerting condition based on `burnedBudget` measurement ("Remaining error budget is ...").
