### PR TITLE
chore: Correct default project for acceptance tests dispatch workflow

### DIFF
--- a/.github/workflows/acc-tests-dispatch.yml
+++ b/.github/workflows/acc-tests-dispatch.yml
@@ -22,7 +22,7 @@ on:
         description: Project name to create the tested objects in
         required: false
         type: string
-        default: ${{ vars.TERRAFORM_NOBL9_PROJECT }}
+        default: terraform-acceptance-tests
 jobs:
   test:
     uses: ./.github/workflows/acc-tests.yml


### PR DESCRIPTION
`vars` scope cannot be used inside `default` value for dispatch inputs.