### PR TITLE
feat: PC-13378 Add static checks to Terraform plan

### DIFF
--- a/nobl9/historical_data_retrieval_schema.go
+++ b/nobl9/historical_data_retrieval_schema.go
@@ -59,7 +59,7 @@ func setHistoricalDataRetrievalSchema(s map[string]*schema.Schema) {
 	s[historicalDataRetrievalConfigKey] = getHistoricalDataRetrievalSchema()[historicalDataRetrievalConfigKey]
 }
 
-func marshalHistoricalDataRetrieval(d *schema.ResourceData) *v1alpha.HistoricalDataRetrieval {
+func marshalHistoricalDataRetrieval(d Data) *v1alpha.HistoricalDataRetrieval {
 	hData, ok := d.GetOk(historicalDataRetrievalConfigKey)
 	if !ok {
 		return nil

--- a/nobl9/historical_data_retrieval_schema.go
+++ b/nobl9/historical_data_retrieval_schema.go
@@ -59,7 +59,7 @@ func setHistoricalDataRetrievalSchema(s map[string]*schema.Schema) {
 	s[historicalDataRetrievalConfigKey] = getHistoricalDataRetrievalSchema()[historicalDataRetrievalConfigKey]
 }
 
-func marshalHistoricalDataRetrieval(d Data) *v1alpha.HistoricalDataRetrieval {
+func marshalHistoricalDataRetrieval(d resourceInterface) *v1alpha.HistoricalDataRetrieval {
 	hData, ok := d.GetOk(historicalDataRetrievalConfigKey)
 	if !ok {
 		return nil

--- a/nobl9/metadata_schema.go
+++ b/nobl9/metadata_schema.go
@@ -78,6 +78,10 @@ func schemaAnnotations() *schema.Schema {
 	}
 }
 
+type Data interface {
+	Get(key string) any
+}
+
 func validateNotEmptyString(variableName string) func(interface{}, string) ([]string, []error) {
 	return func(valueRaw interface{}, _ string) ([]string, []error) {
 		if valueRaw.(string) == "" {

--- a/nobl9/metadata_schema.go
+++ b/nobl9/metadata_schema.go
@@ -186,7 +186,7 @@ func schemaDescription() *schema.Schema {
 	}
 }
 
-func getMarshaledLabels(d *schema.ResourceData) (v1alpha.Labels, diag.Diagnostics) {
+func getMarshaledLabels(d Data) (v1alpha.Labels, diag.Diagnostics) {
 	var labels []interface{}
 	if labelsData := d.Get("label"); labelsData != nil {
 		labels = labelsData.([]interface{})
@@ -194,7 +194,7 @@ func getMarshaledLabels(d *schema.ResourceData) (v1alpha.Labels, diag.Diagnostic
 	return marshalLabels(labels)
 }
 
-func getMarshaledAnnotations(d *schema.ResourceData) v1alpha.MetadataAnnotations {
+func getMarshaledAnnotations(d Data) v1alpha.MetadataAnnotations {
 	rawAnnotations := d.Get("annotations").(map[string]interface{})
 	annotations := make(map[string]string, len(rawAnnotations))
 

--- a/nobl9/metadata_schema.go
+++ b/nobl9/metadata_schema.go
@@ -80,6 +80,7 @@ func schemaAnnotations() *schema.Schema {
 
 type Data interface {
 	Get(key string) any
+	GetOk(key string) (any, bool)
 }
 
 func validateNotEmptyString(variableName string) func(interface{}, string) ([]string, []error) {
@@ -287,6 +288,28 @@ func appendError(d diag.Diagnostics, err error) diag.Diagnostics {
 	}
 
 	return d
+}
+
+func diagsToSingleError(diags diag.Diagnostics) error {
+	if len(diags) == 0 {
+		return nil
+	}
+
+	var errsStrings []string
+	for _, d := range diags {
+		errsStrings = append(errsStrings, fmt.Sprintf("%s: %s", d.Summary, d.Detail))
+	}
+	combinedErrs := strings.Join(errsStrings, "; ")
+	return fmt.Errorf("validation failed: %s", combinedErrs)
+}
+
+func formatErrorsAsSingleError(errs []error) error {
+	var errsStrings []string
+	for _, err := range errs {
+		errsStrings = append(errsStrings, err.Error())
+	}
+	combinedErrs := strings.Join(errsStrings, "; ")
+	return fmt.Errorf("validation failed: %s", strings.Trim(combinedErrs, "[]"))
 }
 
 func toStringSlice(in []interface{}) []string {

--- a/nobl9/query_delay_schema.go
+++ b/nobl9/query_delay_schema.go
@@ -38,7 +38,7 @@ func schemaQueryDelay() *schema.Schema {
 	}
 }
 
-func marshalQueryDelay(d *schema.ResourceData) *v1alpha.QueryDelay {
+func marshalQueryDelay(d Data) *v1alpha.QueryDelay {
 	queryDelay := d.Get(queryDelayConfigKey).(*schema.Set)
 	if queryDelay.Len() > 0 {
 		qd := queryDelay.List()[0].(map[string]interface{})

--- a/nobl9/query_delay_schema.go
+++ b/nobl9/query_delay_schema.go
@@ -38,7 +38,7 @@ func schemaQueryDelay() *schema.Schema {
 	}
 }
 
-func marshalQueryDelay(d Data) *v1alpha.QueryDelay {
+func marshalQueryDelay(d resourceInterface) *v1alpha.QueryDelay {
 	queryDelay := d.Get(queryDelayConfigKey).(*schema.Set)
 	if queryDelay.Len() > 0 {
 		qd := queryDelay.List()[0].(map[string]interface{})

--- a/nobl9/release_channel_schema.go
+++ b/nobl9/release_channel_schema.go
@@ -27,7 +27,7 @@ func schemaReleaseChannel() *schema.Schema {
 	}
 }
 
-func marshalReleaseChannel(d Data, diags diag.Diagnostics) v1alpha.ReleaseChannel {
+func marshalReleaseChannel(d resourceInterface, diags diag.Diagnostics) v1alpha.ReleaseChannel {
 	rc, ok := d.Get(releaseChannel).(string)
 	if !ok {
 		return 0

--- a/nobl9/release_channel_schema.go
+++ b/nobl9/release_channel_schema.go
@@ -27,7 +27,7 @@ func schemaReleaseChannel() *schema.Schema {
 	}
 }
 
-func marshalReleaseChannel(d *schema.ResourceData, diags diag.Diagnostics) v1alpha.ReleaseChannel {
+func marshalReleaseChannel(d Data, diags diag.Diagnostics) v1alpha.ReleaseChannel {
 	rc, ok := d.Get(releaseChannel).(string)
 	if !ok {
 		return 0

--- a/nobl9/resource_agent.go
+++ b/nobl9/resource_agent.go
@@ -24,6 +24,7 @@ const agentTypeKey = "agent_type"
 func resourceAgent() *schema.Resource {
 	return &schema.Resource{
 		Schema:        agentSchema(),
+		CustomizeDiff: resourceAgentValidation,
 		CreateContext: resourceAgentApply,
 		UpdateContext: resourceAgentApply,
 		DeleteContext: resourceAgentDelete,
@@ -115,6 +116,19 @@ func agentSchema() map[string]*schema.Schema {
 	return agentSchema
 }
 
+//nolint:unparam
+func resourceAgentValidation(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	agent, diags := marshalAgent(diff)
+	if diags.HasError() {
+		return diagsToSingleError(diags)
+	}
+	errs := manifest.Validate([]manifest.Object{agent})
+	if errs != nil {
+		return formatErrorsAsSingleError(errs)
+	}
+	return nil
+}
+
 func resourceAgentApply(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ProviderConfig)
 	client, ds := getClient(config)
@@ -201,7 +215,7 @@ func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 //nolint:unparam
-func marshalAgent(d *schema.ResourceData) (*v1alphaAgent.Agent, diag.Diagnostics) {
+func marshalAgent(d Data) (*v1alphaAgent.Agent, diag.Diagnostics) {
 	var displayName string
 	if dn := d.Get("display_name"); dn != nil {
 		displayName = dn.(string)
@@ -410,7 +424,7 @@ func schemaAgentAmazonPrometheus() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentAmazonPrometheus(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.AmazonPrometheusConfig {
+func marshalAgentAmazonPrometheus(d Data, diags diag.Diagnostics) *v1alphaAgent.AmazonPrometheusConfig {
 	data := getAgentResourceData(d, amazonPrometheusAgentType, amazonPrometheusAgentConfigKey, diags)
 
 	if data == nil {
@@ -451,7 +465,7 @@ func schemaAgentAppDynamics() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentAppDynamics(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.AppDynamicsConfig {
+func marshalAgentAppDynamics(d Data, diags diag.Diagnostics) *v1alphaAgent.AppDynamicsConfig {
 	data := getAgentResourceData(d, appDynamicsAgentType, appDynamicsAgentConfigKey, diags)
 
 	if data == nil {
@@ -492,7 +506,7 @@ func schemaAgentAzureMonitor() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentAzureMonitor(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.AzureMonitorConfig {
+func marshalAgentAzureMonitor(d Data, diags diag.Diagnostics) *v1alphaAgent.AzureMonitorConfig {
 	data := getAgentResourceData(d, azureMonitorAgentType, azureMonitorAgentConfigKey, diags)
 
 	if data == nil {
@@ -527,7 +541,7 @@ func schemaAgentBigQuery() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentBigQuery(d *schema.ResourceData) *v1alphaAgent.BigQueryConfig {
+func marshalAgentBigQuery(d Data) *v1alphaAgent.BigQueryConfig {
 	if !isAgentType(d, bigqueryAgentType) {
 		return nil
 	}
@@ -557,7 +571,7 @@ func schemaAgentCloudWatch() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentCloudWatch(d *schema.ResourceData) *v1alphaAgent.CloudWatchConfig {
+func marshalAgentCloudWatch(d Data) *v1alphaAgent.CloudWatchConfig {
 	if !isAgentType(d, cloudWatchAgentType) {
 		return nil
 	}
@@ -594,7 +608,7 @@ func schemaAgentDatadog() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentDatadog(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.DatadogConfig {
+func marshalAgentDatadog(d Data, diags diag.Diagnostics) *v1alphaAgent.DatadogConfig {
 	data := getAgentResourceData(d, datadogAgentType, datadogAgentConfigKey, diags)
 
 	if data == nil {
@@ -634,7 +648,7 @@ func schemaAgentDynatrace() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentDynatrace(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.DynatraceConfig {
+func marshalAgentDynatrace(d Data, diags diag.Diagnostics) *v1alphaAgent.DynatraceConfig {
 	data := getAgentResourceData(d, dynatraceAgentType, dynatraceAgentConfigKey, diags)
 
 	if data == nil {
@@ -674,7 +688,7 @@ func schemaAgentElasticsearch() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentElasticsearch(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.ElasticsearchConfig {
+func marshalAgentElasticsearch(d Data, diags diag.Diagnostics) *v1alphaAgent.ElasticsearchConfig {
 	data := getAgentResourceData(d, elasticsearchAgentType, elasticsearchAgentConfigKey, diags)
 
 	if data == nil {
@@ -709,7 +723,7 @@ func schemaAgentGCM() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentGCM(d *schema.ResourceData) *v1alphaAgent.GCMConfig {
+func marshalAgentGCM(d Data) *v1alphaAgent.GCMConfig {
 	if !isAgentType(d, gcmAgentType) {
 		return nil
 	}
@@ -745,7 +759,7 @@ func schemaAgentGrafanaLoki() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentGrafanaLoki(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.GrafanaLokiConfig {
+func marshalAgentGrafanaLoki(d Data, diags diag.Diagnostics) *v1alphaAgent.GrafanaLokiConfig {
 	data := getAgentResourceData(d, grafanalokiAgentType, grafanalokiAgentConfigKey, diags)
 
 	if data == nil {
@@ -785,7 +799,7 @@ func schemaAgentGraphite() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentGraphite(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.GraphiteConfig {
+func marshalAgentGraphite(d Data, diags diag.Diagnostics) *v1alphaAgent.GraphiteConfig {
 	data := getAgentResourceData(d, graphiteAgentType, graphiteAgentConfigKey, diags)
 
 	if data == nil {
@@ -819,10 +833,11 @@ func schemaAgentHoneycomb() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentHoneycomb(d *schema.ResourceData) *v1alphaAgent.HoneycombConfig {
+func marshalAgentHoneycomb(d Data) *v1alphaAgent.HoneycombConfig {
 	if !isAgentType(d, honeycombAgentType) {
 		return nil
 	}
+
 	return &v1alphaAgent.HoneycombConfig{}
 }
 
@@ -854,7 +869,7 @@ func schemaAgentInfluxDB() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentInfluxDB(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.InfluxDBConfig {
+func marshalAgentInfluxDB(d Data, diags diag.Diagnostics) *v1alphaAgent.InfluxDBConfig {
 	data := getAgentResourceData(d, influxdbAgentType, influxdbAgentConfigKey, diags)
 
 	if data == nil {
@@ -894,7 +909,7 @@ func schemaAgentInstana() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentInstana(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.InstanaConfig {
+func marshalAgentInstana(d Data, diags diag.Diagnostics) *v1alphaAgent.InstanaConfig {
 	data := getAgentResourceData(d, instanaAgentType, instanaAgentConfigKey, diags)
 
 	if data == nil {
@@ -945,7 +960,7 @@ func schemaAgentLightstep() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentLightstep(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.LightstepConfig {
+func marshalAgentLightstep(d Data, diags diag.Diagnostics) *v1alphaAgent.LightstepConfig {
 	data := getAgentResourceData(d, lightstepAgentType, lightstepAgentConfigKey, diags)
 
 	if data == nil {
@@ -987,7 +1002,7 @@ func schemaAgentNewRelic() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentNewRelic(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.NewRelicConfig {
+func marshalAgentNewRelic(d Data, diags diag.Diagnostics) *v1alphaAgent.NewRelicConfig {
 	data := getAgentResourceData(d, newRelicAgentType, newRelicAgentConfigKey, diags)
 	if data == nil {
 		return nil
@@ -1043,7 +1058,7 @@ func schemaAgentOpenTSDB() map[string]*schema.Schema {
 		}}
 }
 
-func marshalAgentOpenTSDB(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.OpenTSDBConfig {
+func marshalAgentOpenTSDB(d Data, diags diag.Diagnostics) *v1alphaAgent.OpenTSDBConfig {
 	data := getAgentResourceData(d, opentsdbAgentType, opentsdbAgentConfigKey, diags)
 
 	if data == nil {
@@ -1076,7 +1091,7 @@ func schemaAgentPingdom() map[string]*schema.Schema {
 		}}
 }
 
-func marshalAgentPingdom(d *schema.ResourceData) *v1alphaAgent.PingdomConfig {
+func marshalAgentPingdom(d Data) *v1alphaAgent.PingdomConfig {
 	if !isAgentType(d, pingdomAgentType) {
 		return nil
 	}
@@ -1112,7 +1127,7 @@ func schemaAgentPrometheus() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentPrometheus(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.PrometheusConfig {
+func marshalAgentPrometheus(d Data, diags diag.Diagnostics) *v1alphaAgent.PrometheusConfig {
 	data := getAgentResourceData(d, prometheusAgentType, prometheusAgentConfigKey, diags)
 
 	if data == nil {
@@ -1147,7 +1162,7 @@ func schemaAgentRedshift() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentRedshift(d *schema.ResourceData) *v1alphaAgent.RedshiftConfig {
+func marshalAgentRedshift(d Data) *v1alphaAgent.RedshiftConfig {
 	if !isAgentType(d, redshiftAgentType) {
 		return nil
 	}
@@ -1183,7 +1198,7 @@ func schemaAgentSplunk() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentSplunk(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.SplunkConfig {
+func marshalAgentSplunk(d Data, diags diag.Diagnostics) *v1alphaAgent.SplunkConfig {
 	data := getAgentResourceData(d, splunkAgentType, splunkAgentConfigKey, diags)
 
 	if data == nil {
@@ -1225,7 +1240,7 @@ func schemaAgentSplunkObservability() map[string]*schema.Schema {
 }
 
 func marshalAgentSplunkObservability(
-	d *schema.ResourceData,
+	d Data,
 	diags diag.Diagnostics) *v1alphaAgent.SplunkObservabilityConfig {
 	data := getAgentResourceData(d, splunkObservabilityAgentType, splunkObservabilityAgentConfigKey, diags)
 
@@ -1266,7 +1281,7 @@ func schemaAgentSumoLogic() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentSumoLogic(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.SumoLogicConfig {
+func marshalAgentSumoLogic(d Data, diags diag.Diagnostics) *v1alphaAgent.SumoLogicConfig {
 	data := getAgentResourceData(d, sumologicAgentType, sumologicAgentConfigKey, diags)
 
 	if data == nil {
@@ -1300,7 +1315,7 @@ func schemaAgentThousandEyes() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentThousandEyes(d *schema.ResourceData) *v1alphaAgent.ThousandEyesConfig {
+func marshalAgentThousandEyes(d Data) *v1alphaAgent.ThousandEyesConfig {
 	if !isAgentType(d, thousandeyesAgentType) {
 		return nil
 	}
@@ -1336,7 +1351,7 @@ func schemaAgentLogicMonitor() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentLogicMonitor(d *schema.ResourceData, diags diag.Diagnostics) *v1alphaAgent.LogicMonitorConfig {
+func marshalAgentLogicMonitor(d Data, diags diag.Diagnostics) *v1alphaAgent.LogicMonitorConfig {
 	data := getAgentResourceData(d, logicMonitorAgentType, logicMonitorAgentConfigKey, diags)
 
 	if data == nil {
@@ -1349,7 +1364,7 @@ func marshalAgentLogicMonitor(d *schema.ResourceData, diags diag.Diagnostics) *v
 }
 
 func getAgentResourceData(
-	d *schema.ResourceData,
+	d Data,
 	agentType,
 	agentConfigKey string,
 	diags diag.Diagnostics) map[string]interface{} {
@@ -1366,7 +1381,7 @@ func getAgentResourceData(
 	return resourceData
 }
 
-func isAgentType(d *schema.ResourceData, agentType string) bool {
+func isAgentType(d Data, agentType string) bool {
 	agentTypeResource := d.Get(agentTypeKey).(string)
 	return agentTypeResource == agentType
 }

--- a/nobl9/resource_agent.go
+++ b/nobl9/resource_agent.go
@@ -215,7 +215,7 @@ func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 //nolint:unparam
-func marshalAgent(d Data) (*v1alphaAgent.Agent, diag.Diagnostics) {
+func marshalAgent(d resourceInterface) (*v1alphaAgent.Agent, diag.Diagnostics) {
 	var displayName string
 	if dn := d.Get("display_name"); dn != nil {
 		displayName = dn.(string)
@@ -424,7 +424,7 @@ func schemaAgentAmazonPrometheus() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentAmazonPrometheus(d Data, diags diag.Diagnostics) *v1alphaAgent.AmazonPrometheusConfig {
+func marshalAgentAmazonPrometheus(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.AmazonPrometheusConfig {
 	data := getAgentResourceData(d, amazonPrometheusAgentType, amazonPrometheusAgentConfigKey, diags)
 
 	if data == nil {
@@ -465,7 +465,7 @@ func schemaAgentAppDynamics() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentAppDynamics(d Data, diags diag.Diagnostics) *v1alphaAgent.AppDynamicsConfig {
+func marshalAgentAppDynamics(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.AppDynamicsConfig {
 	data := getAgentResourceData(d, appDynamicsAgentType, appDynamicsAgentConfigKey, diags)
 
 	if data == nil {
@@ -506,7 +506,7 @@ func schemaAgentAzureMonitor() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentAzureMonitor(d Data, diags diag.Diagnostics) *v1alphaAgent.AzureMonitorConfig {
+func marshalAgentAzureMonitor(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.AzureMonitorConfig {
 	data := getAgentResourceData(d, azureMonitorAgentType, azureMonitorAgentConfigKey, diags)
 
 	if data == nil {
@@ -541,7 +541,7 @@ func schemaAgentBigQuery() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentBigQuery(d Data) *v1alphaAgent.BigQueryConfig {
+func marshalAgentBigQuery(d resourceInterface) *v1alphaAgent.BigQueryConfig {
 	if !isAgentType(d, bigqueryAgentType) {
 		return nil
 	}
@@ -571,7 +571,7 @@ func schemaAgentCloudWatch() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentCloudWatch(d Data) *v1alphaAgent.CloudWatchConfig {
+func marshalAgentCloudWatch(d resourceInterface) *v1alphaAgent.CloudWatchConfig {
 	if !isAgentType(d, cloudWatchAgentType) {
 		return nil
 	}
@@ -608,7 +608,7 @@ func schemaAgentDatadog() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentDatadog(d Data, diags diag.Diagnostics) *v1alphaAgent.DatadogConfig {
+func marshalAgentDatadog(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.DatadogConfig {
 	data := getAgentResourceData(d, datadogAgentType, datadogAgentConfigKey, diags)
 
 	if data == nil {
@@ -648,7 +648,7 @@ func schemaAgentDynatrace() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentDynatrace(d Data, diags diag.Diagnostics) *v1alphaAgent.DynatraceConfig {
+func marshalAgentDynatrace(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.DynatraceConfig {
 	data := getAgentResourceData(d, dynatraceAgentType, dynatraceAgentConfigKey, diags)
 
 	if data == nil {
@@ -688,7 +688,7 @@ func schemaAgentElasticsearch() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentElasticsearch(d Data, diags diag.Diagnostics) *v1alphaAgent.ElasticsearchConfig {
+func marshalAgentElasticsearch(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.ElasticsearchConfig {
 	data := getAgentResourceData(d, elasticsearchAgentType, elasticsearchAgentConfigKey, diags)
 
 	if data == nil {
@@ -723,7 +723,7 @@ func schemaAgentGCM() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentGCM(d Data) *v1alphaAgent.GCMConfig {
+func marshalAgentGCM(d resourceInterface) *v1alphaAgent.GCMConfig {
 	if !isAgentType(d, gcmAgentType) {
 		return nil
 	}
@@ -759,7 +759,7 @@ func schemaAgentGrafanaLoki() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentGrafanaLoki(d Data, diags diag.Diagnostics) *v1alphaAgent.GrafanaLokiConfig {
+func marshalAgentGrafanaLoki(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.GrafanaLokiConfig {
 	data := getAgentResourceData(d, grafanalokiAgentType, grafanalokiAgentConfigKey, diags)
 
 	if data == nil {
@@ -799,7 +799,7 @@ func schemaAgentGraphite() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentGraphite(d Data, diags diag.Diagnostics) *v1alphaAgent.GraphiteConfig {
+func marshalAgentGraphite(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.GraphiteConfig {
 	data := getAgentResourceData(d, graphiteAgentType, graphiteAgentConfigKey, diags)
 
 	if data == nil {
@@ -833,7 +833,7 @@ func schemaAgentHoneycomb() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentHoneycomb(d Data) *v1alphaAgent.HoneycombConfig {
+func marshalAgentHoneycomb(d resourceInterface) *v1alphaAgent.HoneycombConfig {
 	if !isAgentType(d, honeycombAgentType) {
 		return nil
 	}
@@ -869,7 +869,7 @@ func schemaAgentInfluxDB() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentInfluxDB(d Data, diags diag.Diagnostics) *v1alphaAgent.InfluxDBConfig {
+func marshalAgentInfluxDB(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.InfluxDBConfig {
 	data := getAgentResourceData(d, influxdbAgentType, influxdbAgentConfigKey, diags)
 
 	if data == nil {
@@ -909,7 +909,7 @@ func schemaAgentInstana() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentInstana(d Data, diags diag.Diagnostics) *v1alphaAgent.InstanaConfig {
+func marshalAgentInstana(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.InstanaConfig {
 	data := getAgentResourceData(d, instanaAgentType, instanaAgentConfigKey, diags)
 
 	if data == nil {
@@ -960,7 +960,7 @@ func schemaAgentLightstep() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentLightstep(d Data, diags diag.Diagnostics) *v1alphaAgent.LightstepConfig {
+func marshalAgentLightstep(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.LightstepConfig {
 	data := getAgentResourceData(d, lightstepAgentType, lightstepAgentConfigKey, diags)
 
 	if data == nil {
@@ -1002,7 +1002,7 @@ func schemaAgentNewRelic() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentNewRelic(d Data, diags diag.Diagnostics) *v1alphaAgent.NewRelicConfig {
+func marshalAgentNewRelic(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.NewRelicConfig {
 	data := getAgentResourceData(d, newRelicAgentType, newRelicAgentConfigKey, diags)
 	if data == nil {
 		return nil
@@ -1058,7 +1058,7 @@ func schemaAgentOpenTSDB() map[string]*schema.Schema {
 		}}
 }
 
-func marshalAgentOpenTSDB(d Data, diags diag.Diagnostics) *v1alphaAgent.OpenTSDBConfig {
+func marshalAgentOpenTSDB(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.OpenTSDBConfig {
 	data := getAgentResourceData(d, opentsdbAgentType, opentsdbAgentConfigKey, diags)
 
 	if data == nil {
@@ -1091,7 +1091,7 @@ func schemaAgentPingdom() map[string]*schema.Schema {
 		}}
 }
 
-func marshalAgentPingdom(d Data) *v1alphaAgent.PingdomConfig {
+func marshalAgentPingdom(d resourceInterface) *v1alphaAgent.PingdomConfig {
 	if !isAgentType(d, pingdomAgentType) {
 		return nil
 	}
@@ -1127,7 +1127,7 @@ func schemaAgentPrometheus() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentPrometheus(d Data, diags diag.Diagnostics) *v1alphaAgent.PrometheusConfig {
+func marshalAgentPrometheus(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.PrometheusConfig {
 	data := getAgentResourceData(d, prometheusAgentType, prometheusAgentConfigKey, diags)
 
 	if data == nil {
@@ -1162,7 +1162,7 @@ func schemaAgentRedshift() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentRedshift(d Data) *v1alphaAgent.RedshiftConfig {
+func marshalAgentRedshift(d resourceInterface) *v1alphaAgent.RedshiftConfig {
 	if !isAgentType(d, redshiftAgentType) {
 		return nil
 	}
@@ -1198,7 +1198,7 @@ func schemaAgentSplunk() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentSplunk(d Data, diags diag.Diagnostics) *v1alphaAgent.SplunkConfig {
+func marshalAgentSplunk(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.SplunkConfig {
 	data := getAgentResourceData(d, splunkAgentType, splunkAgentConfigKey, diags)
 
 	if data == nil {
@@ -1240,7 +1240,7 @@ func schemaAgentSplunkObservability() map[string]*schema.Schema {
 }
 
 func marshalAgentSplunkObservability(
-	d Data,
+	d resourceInterface,
 	diags diag.Diagnostics) *v1alphaAgent.SplunkObservabilityConfig {
 	data := getAgentResourceData(d, splunkObservabilityAgentType, splunkObservabilityAgentConfigKey, diags)
 
@@ -1281,7 +1281,7 @@ func schemaAgentSumoLogic() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentSumoLogic(d Data, diags diag.Diagnostics) *v1alphaAgent.SumoLogicConfig {
+func marshalAgentSumoLogic(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.SumoLogicConfig {
 	data := getAgentResourceData(d, sumologicAgentType, sumologicAgentConfigKey, diags)
 
 	if data == nil {
@@ -1315,7 +1315,7 @@ func schemaAgentThousandEyes() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentThousandEyes(d Data) *v1alphaAgent.ThousandEyesConfig {
+func marshalAgentThousandEyes(d resourceInterface) *v1alphaAgent.ThousandEyesConfig {
 	if !isAgentType(d, thousandeyesAgentType) {
 		return nil
 	}
@@ -1351,7 +1351,7 @@ func schemaAgentLogicMonitor() map[string]*schema.Schema {
 	}
 }
 
-func marshalAgentLogicMonitor(d Data, diags diag.Diagnostics) *v1alphaAgent.LogicMonitorConfig {
+func marshalAgentLogicMonitor(d resourceInterface, diags diag.Diagnostics) *v1alphaAgent.LogicMonitorConfig {
 	data := getAgentResourceData(d, logicMonitorAgentType, logicMonitorAgentConfigKey, diags)
 
 	if data == nil {
@@ -1364,7 +1364,7 @@ func marshalAgentLogicMonitor(d Data, diags diag.Diagnostics) *v1alphaAgent.Logi
 }
 
 func getAgentResourceData(
-	d Data,
+	d resourceInterface,
 	agentType,
 	agentConfigKey string,
 	diags diag.Diagnostics) map[string]interface{} {
@@ -1381,7 +1381,7 @@ func getAgentResourceData(
 	return resourceData
 }
 
-func isAgentType(d Data, agentType string) bool {
+func isAgentType(d resourceInterface, agentType string) bool {
 	agentTypeResource := d.Get(agentTypeKey).(string)
 	return agentTypeResource == agentType
 }

--- a/nobl9/resource_project.go
+++ b/nobl9/resource_project.go
@@ -3,6 +3,7 @@ package nobl9
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -110,7 +111,12 @@ func resourceProjectValidation(ctx context.Context, diff *schema.ResourceDiff, m
 		errs = append(errs, validationErrors...)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("validation failed: %v", errs)
+		var errsStrings []string
+		for _, err := range errs {
+			errsStrings = append(errsStrings, err.Error())
+		}
+		combinedErrs := strings.Join(errsStrings, "; ")
+		return fmt.Errorf("validation failed: %s", strings.Trim(combinedErrs, "[]"))
 	}
 	return nil
 }

--- a/nobl9/resource_project.go
+++ b/nobl9/resource_project.go
@@ -31,7 +31,7 @@ func resourceProject() *schema.Resource {
 	}
 }
 
-func marshalProject(d Data) (*v1alphaProject.Project, diag.Diagnostics) {
+func marshalProject(d resourceInterface) (*v1alphaProject.Project, diag.Diagnostics) {
 	labelsMarshaled, diags := getMarshaledLabels(d)
 	if diags.HasError() {
 		return nil, diags

--- a/nobl9/resource_service.go
+++ b/nobl9/resource_service.go
@@ -41,7 +41,7 @@ func resourceService() *schema.Resource {
 	}
 }
 
-func marshalService(d Data) (*v1alphaService.Service, diag.Diagnostics) {
+func marshalService(d resourceInterface) (*v1alphaService.Service, diag.Diagnostics) {
 	var displayName string
 	if dn := d.Get("display_name"); dn != nil {
 		displayName = dn.(string)

--- a/nobl9/resource_service.go
+++ b/nobl9/resource_service.go
@@ -3,6 +3,7 @@ package nobl9
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -132,11 +133,12 @@ func resourceServiceValidation(ctx context.Context, diff *schema.ResourceDiff, m
 		errs = append(errs, validationErrors...)
 	}
 	if len(errs) > 0 {
-		var combinedErrs string
+		var errsStrings []string
 		for _, err := range errs {
-			combinedErrs += err.Error() + "; "
+			errsStrings = append(errsStrings, err.Error())
 		}
-		return fmt.Errorf("validation failed: %s", combinedErrs)
+		combinedErrs := strings.Join(errsStrings, "; ")
+		return fmt.Errorf("validation failed: %s", strings.Trim(combinedErrs, "[]"))
 	}
 	return nil
 }

--- a/nobl9/resource_service.go
+++ b/nobl9/resource_service.go
@@ -42,7 +42,7 @@ func resourceService() *schema.Resource {
 	}
 }
 
-func marshalService(d Data) (*v1alphaService.Service, diag.Diagnostics) {
+func marshalService(d *schema.ResourceData) (*v1alphaService.Service, diag.Diagnostics) {
 	var displayName string
 	if dn := d.Get("display_name"); dn != nil {
 		displayName = dn.(string)

--- a/nobl9/resource_service.go
+++ b/nobl9/resource_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/nobl9/nobl9-go/manifest"
 	v1alphaService "github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 	v1Objects "github.com/nobl9/nobl9-go/sdk/endpoints/objects/v1"
@@ -39,10 +40,6 @@ func resourceService() *schema.Resource {
 		},
 		Description: "[Service configuration | Nobl9 Documentation](https://docs.nobl9.com/yaml-guide#service)",
 	}
-}
-
-type Data interface {
-	Get(key string) any
 }
 
 func marshalService(d Data) (*v1alphaService.Service, diag.Diagnostics) {


### PR DESCRIPTION
## Motivation

Validating resources at the stage of `terraform plan` instead of `terraform apply` will shorten the developer's feedback loop.

## Summary

Added static checks from SDK to `project`, `service` and `agent` resources.


## Release Notes

If this change should be part of the Release Notes,
**replace this entire paragraph** with 1-3 sentences about the changes.
Otherwise, you **MUST** remove this section entirely.

Does this PR contain any breaking changes?
If so, add `## Breaking Changes` header and list the introduced changes there.
