### PR TITLE
chore: PC-13868 Fix composite 2.0 block uniqueness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAMESPACE=nobl9
 NAME=nobl9
 BIN_DIR=./bin
 BINARY=$(BIN_DIR)/terraform-provider-$(NAME)
-VERSION=0.28.0
+VERSION=0.29.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.28.0"
+      version = "0.29.0"
     }
   }
 }

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -229,7 +229,7 @@ Required:
 
 Optional:
 
-- `composite` (Block Set) An assembly of objectives from different SLOs reflecting their combined performance. (see [below for nested schema](#nestedblock--objective--composite))
+- `composite` (Block Set, Max: 1) An assembly of objectives from different SLOs reflecting their combined performance. (see [below for nested schema](#nestedblock--objective--composite))
 - `count_metrics` (Block Set) Compares two time series, calculating the ratio of either good or bad values to the total number of values. Fill either the 'good' or 'bad' series, but not both. (see [below for nested schema](#nestedblock--objective--count_metrics))
 - `display_name` (String) Name to be displayed.
 - `name` (String) Objective's name. This field is computed if not provided.

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -247,14 +247,14 @@ Required:
 
 Optional:
 
-- `components` (Block Set) Objectives to be assembled in your composite SLO. (see [below for nested schema](#nestedblock--objective--composite--components))
+- `components` (Block Set, Max: 1) Objectives to be assembled in your composite SLO. (see [below for nested schema](#nestedblock--objective--composite--components))
 
 <a id="nestedblock--objective--composite--components"></a>
 ### Nested Schema for `objective.composite.components`
 
 Optional:
 
-- `objectives` (Block Set) An additional nesting for the components of your composite SLO. (see [below for nested schema](#nestedblock--objective--composite--components--objectives))
+- `objectives` (Block Set, Max: 1) An additional nesting for the components of your composite SLO. (see [below for nested schema](#nestedblock--objective--composite--components--objectives))
 
 <a id="nestedblock--objective--composite--components--objectives"></a>
 ### Nested Schema for `objective.composite.components.objectives`

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -120,6 +120,7 @@ func resourceObjective() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "An assembly of objectives from different SLOs reflecting their combined performance.",
+				MaxItems:    1,
 				Elem:        resourceComposite(),
 			},
 			"display_name": {

--- a/nobl9/resource_slo_composite.go
+++ b/nobl9/resource_slo_composite.go
@@ -20,6 +20,7 @@ func resourceComposite() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Objectives to be assembled in your composite SLO.",
+				MaxItems:    1,
 				Elem:        resourceCompositeComponents(),
 			},
 		},
@@ -33,6 +34,7 @@ func resourceCompositeComponents() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "An additional nesting for the components of your composite SLO.",
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"composite_objective": {


### PR DESCRIPTION
## Motivation

Adding a uniqueness requirement on composite 2.0 SLO blocks `composite`, `components` and `objectives` would make the composite 2.0 SLOs creation process more intuitive.

## Summary

Added a uniqueness requirement on composite 2.0 SLO blocks `composite`, `components` and `objectives`.
