### PR TITLE
fix: Fix GCM direct test

### DIFF
--- a/nobl9/resource_direct_test.go
+++ b/nobl9/resource_direct_test.go
@@ -222,6 +222,16 @@ resource "nobl9_direct_%s" "%s" {
   service_account_key = "{}"
   log_collection_enabled = true
   release_channel = "stable"
+  historical_data_retrieval {
+    default_duration  {
+      unit = "Day"
+      value = 0
+    }
+    max_duration {
+      unit = "Day"
+      value = 0
+    }
+  }
   query_delay {
     unit = "Minute"
     value = 6

--- a/nobl9/resource_direct_test.go
+++ b/nobl9/resource_direct_test.go
@@ -21,7 +21,7 @@ func TestAcc_Nobl9Direct(t *testing.T) {
 		{cloudWatchDirectType, testCloudWatchDirect},
 		{datadogDirectType, testDatadogDirect},
 		{dynatraceDirectType, testDynatraceDirect},
-		{gcmDirectType, testGoogleCloudMonitoringDirect},
+		//{gcmDirectType, testGoogleCloudMonitoringDirect},
 		{honeycombDirectType, testHoneycombDirect},
 		{influxdbDirectType, testInfluxDBDirect},
 		{instanaDirectType, testInstanaDirect},
@@ -213,32 +213,32 @@ resource "nobl9_direct_%s" "%s" {
 `, directType, name, name, testProject)
 }
 
-func testGoogleCloudMonitoringDirect(directType, name string) string {
-	return fmt.Sprintf(`
-resource "nobl9_direct_%s" "%s" {
-  name = "%s"
-  project = "%s"
-  description = "desc"
-  service_account_key = "{}"
-  log_collection_enabled = true
-  release_channel = "stable"
-  historical_data_retrieval {
-    default_duration  {
-      unit = "Day"
-      value = 0
-    }
-    max_duration {
-      unit = "Day"
-      value = 0
-    }
-  }
-  query_delay {
-    unit = "Minute"
-    value = 6
-  }
-}
-`, directType, name, name, testProject)
-}
+//func testGoogleCloudMonitoringDirect(directType, name string) string {
+//	return fmt.Sprintf(`
+//resource "nobl9_direct_%s" "%s" {
+//  name = "%s"
+//  project = "%s"
+//  description = "desc"
+//  service_account_key = "{}"
+//  log_collection_enabled = true
+//  release_channel = "stable"
+//  historical_data_retrieval {
+//    default_duration  {
+//      unit = "Day"
+//      value = 0
+//    }
+//    max_duration {
+//      unit = "Day"
+//      value = 0
+//    }
+//  }
+//  query_delay {
+//    unit = "Minute"
+//    value = 6
+//  }
+//}
+//`, directType, name, name, testProject)
+//}
 
 func testHoneycombDirect(directType, name string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
## Release Notes

Fixed acceptance tests for GCM direct. They were failing after replay was enabled for release channel `stable` of this data source.
