### PR TITLE
chore: Update crazy-max/ghaction-import-gpg to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           check-latest: true
       - name: Import GPG key
         id: import_gpg
-        uses:  crazy-max/ghaction-import-gpg@v5
+        uses:  crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_2024_03 }}
           passphrase: ${{ secrets.PASSPHRASE_2024_03 }}


### PR DESCRIPTION
## Motivation

v5 uses node 16, which is unsupported by GHA