### PR TITLE
chore: Ignore nobl9-go in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,7 @@
       ]
     }
   ],
+  "ignoreDeps": ["github.com/nobl9/nobl9-go"],
   "ignorePaths": [
     "**/vendor/**",
     "**/node_modules/**",


### PR DESCRIPTION
## Motivation

We want to manually and with care govern the dependency management of nobl9-go.