### PR TITLE
chore: fix Splunk Observability acceptance test [PC-14221]

### DIFF
--- a/nobl9/resource_agent_test.go
+++ b/nobl9/resource_agent_test.go
@@ -537,7 +537,7 @@ resource "nobl9_agent" "%s" {
   splunk_observability_config {
     realm = "eu"
   }
-  release_channel = "beta"
+  release_channel = "alpha"
   query_delay {
     unit = "Minute"
     value = 6


### PR DESCRIPTION
## Motivation

Splunk Observability only works in the `alpha` release channel. These changes updates the acceptance test to the new behavior.

## Release Notes
