### PR TITLE
chore: Bump version number for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.29.2"
+      version = "0.30.0"
     }
   }
 }


### PR DESCRIPTION
## Motivation

We want to keep examples in readme up to date.

## Summary

Bumped version referenced in readme examples to the next published verstion.