### PR TITLE
chore: Update gofmt usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ format/go:
 	echo "Formatting Go files..."
 	$(call _ensure_installed,binary,goimports)
 	$(call _ensure_installed,binary,golines)
-	go fmt ./...
+	gofmt -w -l -s .
 	$(BIN_DIR)/goimports -local=github.com/nobl9/terraform-provider-nobl9 -w .
 	$(BIN_DIR)/golines --ignore-generated -m 120 -w .
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -31,6 +31,7 @@ words:
   - dynatrace
   - endef
   - gobin
+  - gofmt
   - goimports
   - golangci
   - golines


### PR DESCRIPTION
By default `go fmt` calls `gofmt -w -l`, with the recent golangci linter changes it seems it's not enough, and rightfully so.
It now requires the files to be formatted with `-s` flag which simplifies code, for instance removing unnecessary type literals in slice declarations. 

Example linter fail due to unsimplified code: https://github.com/nobl9/nobl9-go/actions/runs/11123928510/job/30908411560