### PR TITLE
chore: Unparallel SLO and SLO Errors tests

### DIFF
--- a/nobl9/resource_slo_test.go
+++ b/nobl9/resource_slo_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/nobl9/nobl9-go/manifest"
 )
 
-//nolint:tparallel
 func TestAcc_Nobl9SLO(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		name       string
 		configFunc func(string) string
@@ -83,9 +81,7 @@ func TestAcc_Nobl9SLO(t *testing.T) {
 	}
 }
 
-//nolint:tparallel
 func TestAcc_Nobl9SLOErrors(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		name         string
 		configFunc   func(string) string


### PR DESCRIPTION
## Summary

Removed "t.Parallel" setting from two tests that are negatively affected by it.
