### PR TITLE
fix: Typo in alerting measurement name in docs

### DIFF
--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -291,7 +291,7 @@ resource "nobl9_alert_policy" "slow_budget_drop" {
 
 Required:
 
-- `measurement` (String) One of `timeToBurnBudget` | `timeToBurnEntireBudget` | `burnRate` | `burnedBudget` | `budgetDrop`.
+- `measurement` (String) One of `timeToBurnBudget` | `timeToBurnEntireBudget` | `averageBurnRate` | `burnedBudget` | `budgetDrop`.
 
 Optional:
 

--- a/nobl9/resource_alert_policy.go
+++ b/nobl9/resource_alert_policy.go
@@ -43,7 +43,7 @@ func resourceAlertPolicy() *schema.Resource {
 						"measurement": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "One of `timeToBurnBudget` | `timeToBurnEntireBudget` | `burnRate` | `burnedBudget` | `budgetDrop`.",
+							Description: "One of `timeToBurnBudget` | `timeToBurnEntireBudget` | `averageBurnRate` | `burnedBudget` | `budgetDrop`.",
 						},
 						"value": {
 							Type:        schema.TypeFloat,


### PR DESCRIPTION
## Motivation

Typo in measurement name in documentation. Instead of `burnRate` it's expected to see provide `averageBurnRate` measurement name.

## Summary

Fixed docs `burnRate` => `averageBurnRate`.