### PR TITLE
feat: Trigger replay on SLO creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAMESPACE=nobl9
 NAME=nobl9
 BIN_DIR=./bin
 BINARY=$(BIN_DIR)/terraform-provider-$(NAME)
-VERSION=0.31.0
+VERSION=0.32.0
 BUILD_FLAGS="-X github.com/nobl9/terraform-provider-nobl9/nobl9.Version=$(VERSION)"
 OS_ARCH?=linux_amd64
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.31.0"
+      version = "0.32.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.31.0"
+      version = "0.32.0"
     }
   }
 }

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -215,6 +215,7 @@ resource "nobl9_slo" "composite_slo" {
 - `indicator` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--indicator))
 - `label` (Block List) [Labels](https://docs.nobl9.com/features/labels/) containing a single key and a list of values. (see [below for nested schema](#nestedblock--label))
 - `tier` (String) Internal field, do not use.
+- `retrieve_historical_data_from` (String) If set, the retrieval of historical data for this SLO will be triggered, starting from the specified date.
 
 ### Read-Only
 

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -214,8 +214,8 @@ resource "nobl9_slo" "composite_slo" {
 - `display_name` (String) User-friendly display name of the resource.
 - `indicator` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--indicator))
 - `label` (Block List) [Labels](https://docs.nobl9.com/features/labels/) containing a single key and a list of values. (see [below for nested schema](#nestedblock--label))
-- `tier` (String) Internal field, do not use.
 - `retrieve_historical_data_from` (String) If set, the retrieval of historical data for this SLO will be triggered, starting from the specified date.
+- `tier` (String) Internal field, do not use.
 
 ### Read-Only
 

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -214,7 +214,7 @@ resource "nobl9_slo" "composite_slo" {
 - `display_name` (String) User-friendly display name of the resource.
 - `indicator` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--indicator))
 - `label` (Block List) [Labels](https://docs.nobl9.com/features/labels/) containing a single key and a list of values. (see [below for nested schema](#nestedblock--label))
-- `retrieve_historical_data_from` (String) If set, the retrieval of historical data for a newly created SLO will be triggered, starting from the specified date.
+- `retrieve_historical_data_from` (String) If set, the retrieval of historical data for a newly created SLO will be triggered, starting from the specified date. Needs to be RFC3339 format.
 - `tier` (String) Internal field, do not use.
 
 ### Read-Only

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -214,7 +214,7 @@ resource "nobl9_slo" "composite_slo" {
 - `display_name` (String) User-friendly display name of the resource.
 - `indicator` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--indicator))
 - `label` (Block List) [Labels](https://docs.nobl9.com/features/labels/) containing a single key and a list of values. (see [below for nested schema](#nestedblock--label))
-- `retrieve_historical_data_from` (String) If set, the retrieval of historical data for this SLO will be triggered, starting from the specified date.
+- `retrieve_historical_data_from` (String) If set, the retrieval of historical data for a newly created SLO will be triggered, starting from the specified date.
 - `tier` (String) Internal field, do not use.
 
 ### Read-Only

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.31.0"
+      version = "0.32.0"
     }
   }
 }

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -340,7 +340,7 @@ func schemaSLO() map[string]*schema.Schema {
 			Optional:         true,
 			ValidateDiagFunc: validateDateTime,
 			Description: "If set, the retrieval of historical data for a newly created SLO will be triggered, " +
-				"starting from the specified date.",
+				"starting from the specified date. Needs to be RFC3339 format.",
 		},
 	}
 }

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -337,12 +337,17 @@ func schemaSLO() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Optional:         true,
 			ValidateDiagFunc: validateDateTime,
-			Description:      "If set, the retrieval of historical data for this SLO will be triggered, starting from the specified date.",
+			Description: "If set, the retrieval of historical data for this SLO will be triggered, " +
+				"starting from the specified date.",
 		},
 	}
 }
 
-func resourceSLOApply(ctx context.Context, d *schema.ResourceData, meta interface{}) (diag.Diagnostics, manifest.ProjectScopedObject) {
+func resourceSLOApply(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) (diag.Diagnostics, manifest.ProjectScopedObject) {
 	config := meta.(ProviderConfig)
 	client, ds := getClient(config)
 	if ds != nil {
@@ -2852,7 +2857,7 @@ const historicalDataRetrievalEndpoint = "/timetravel"
 func buildReplayPayload(project, sloName, replayFrom string) sdkModels.Replay {
 	replayFromTs, _ := time.Parse(time.RFC3339, replayFrom)
 	const startOffsetMinutes = 5
-	windowDuration := time.Now().Sub(replayFromTs)
+	windowDuration := time.Since(replayFromTs)
 	return sdkModels.Replay{
 		Project: project,
 		Slo:     sloName,

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -337,7 +337,7 @@ func schemaSLO() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Optional:         true,
 			ValidateDiagFunc: validateDateTime,
-			Description:      "If set, a retrieval of historical data for this SLO will be triggered starting from the provided date.",
+			Description:      "If set, the retrieval of historical data for this SLO will be triggered, starting from the specified date.",
 		},
 	}
 }
@@ -378,8 +378,8 @@ func resourceSLOUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	if retrieveHistoricalDataFrom != "" {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  "Unsupported `retrieve_historical_data_from` parameter for SLO update",
-			Detail:   "Triggering historical data retrieval for SLO is supported only when creating new SLO object",
+			Summary:  "The `retrieve_historical_data_from` parameter is not supported for SLO updates.",
+			Detail:   "Triggering historical data retrieval for an SLO is supported only when creating a new SLO object.",
 		})
 	}
 	return diags
@@ -403,7 +403,7 @@ func resourceSLOCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  "Historical data retrieval for SLO has been triggered",
+			Summary:  "Historical data retrieval for the SLO has been triggered.",
 		})
 	}
 

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -379,14 +379,6 @@ func resourceSLOApply(
 
 func resourceSLOUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags, _ := resourceSLOApply(ctx, d, meta)
-	retrieveHistoricalDataFrom := d.Get("retrieve_historical_data_from").(string)
-	if retrieveHistoricalDataFrom != "" {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "The `retrieve_historical_data_from` parameter is not supported for SLO updates.",
-			Detail:   "Triggering historical data retrieval for an SLO is supported only when creating a new SLO object.",
-		})
-	}
 	return diags
 }
 

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -337,7 +337,6 @@ func schemaSLO() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Replay from date.",
-			MaxItems:    1,
 		},
 	}
 }

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -2847,7 +2847,8 @@ func triggerReplay(
 		}
 		body = buf
 	}
-	req, err := client.CreateRequest(ctx, http.MethodPost, endpointReplay, nil, nil, body)
+	header := http.Header{sdk.HeaderProject: []string{client.Config.Project}}
+	req, err := client.CreateRequest(ctx, http.MethodPost, endpointReplay, header, nil, body)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -2887,16 +2888,17 @@ func triggerHistoricalDataRetrieval(
 	var data []byte
 	data, err = io.ReadAll(resp.Body)
 	if resp.StatusCode >= 300 {
-		return errors.New(replayUnavailabilityReasonExplanation(string(data), resp.StatusCode))
+		return errors.New(replayUnavailabilityReasonExplanation(data, resp.StatusCode))
 	}
 	return err
 }
 
 func replayUnavailabilityReasonExplanation(
-	reason string,
+	reason []byte,
 	statusCode int,
 ) string {
-	switch reason {
+	strReason := strings.TrimSpace(string(reason))
+	switch strReason {
 	case sdkModels.ReplayIntegrationDoesNotSupportReplay:
 		return "The Data Source does not support Replay yet"
 	case sdkModels.ReplayAgentVersionDoesNotSupportReplay:
@@ -2915,6 +2917,6 @@ func replayUnavailabilityReasonExplanation(
 	case "promql_in_gcm_not_supported":
 		return "Historical data retrieval for PromQL metrics is not supported"
 	default:
-		return fmt.Sprintf("bad response (status: %d): %s", statusCode, reason)
+		return fmt.Sprintf("bad response (status: %d): %s", statusCode, strReason)
 	}
 }

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -337,7 +337,7 @@ func schemaSLO() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Optional:         true,
 			ValidateDiagFunc: validateDateTime,
-			Description: "If set, the retrieval of historical data for this SLO will be triggered, " +
+			Description: "If set, the retrieval of historical data for a newly created SLO will be triggered, " +
 				"starting from the specified date.",
 		},
 	}


### PR DESCRIPTION
## Motivation
Allow Nobl9 users to automatically launch historical data retrieval (Replay) when creating new SLOs using the Nobl9 Terraform Provider.

## Summary

Introduces the ability to trigger a replay (historical data retrieval) for a newly created SLO by adding the `retrieve_historical_data_from` parameter. Appropriate messaging is provided to the user.

**Caveats:**

- The SLO is created regardless of the success of the Replay trigger.  
- Replay availability for the datasource used by the SLO is not validated.  
- All Replay errors are printed.

**Example**
`retrieve_historical_data_from  = "2024-11-14T13:00:00Z"`

This feature is most useful when aligned with the Playlist (Replay queues) feature; however, it is fully functional with current slot limitations.

<img width="1315" alt="Zrzut ekranu 2024-11-15 o 10 57 48" src="https://github.com/user-attachments/assets/a7ef05c4-a21f-471d-8070-b5ac6ed4c178">

## Testing

Creating and updating multiple SLOs with datasources that both support and don't support replay. Also, try creating more than the available slots.

## Release Notes

Add the ability to trigger historical data retrieval when creating a new SLO.