### PR TITLE
Improve docs for target and value fields in SLO resources

### DIFF
--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -131,12 +131,12 @@ func resourceObjective() *schema.Resource {
 			"op": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Type of logical operation.",
+				Description: "For threshold metrics, the logical operator applied to the threshold.",
 			},
 			"target": {
 				Type:        schema.TypeFloat,
 				Required:    true,
-				Description: "Designated value.",
+				Description: "The numeric target for your objective.",
 			},
 			"time_slice_target": {
 				Type:        schema.TypeFloat,
@@ -146,7 +146,7 @@ func resourceObjective() *schema.Resource {
 			"value": {
 				Type:        schema.TypeFloat,
 				Required:    true,
-				Description: "Value.",
+				Description: "For threshold metrics, the threshold value. For ratio metrics, this must be a unique value per objective."
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/nobl9/resource_slo_composite.go
+++ b/nobl9/resource_slo_composite.go
@@ -95,7 +95,7 @@ func schemaCompositeDeprecated() *schema.Schema {
 				"target": {
 					Type:        schema.TypeFloat,
 					Required:    true,
-					Description: "Designated value.",
+					Description: "The numeric target for your objective.",
 				},
 				"burn_rate_condition": {
 					Type:        schema.TypeSet,


### PR DESCRIPTION
## Motivation

While creating my first multiple-objective ratio SLOs with Terraform, I was surprised to receive an error on `apply` which required the `objective.value` field to be unique. I was even more surprised when I read the module documentation, which informs me that `target` is a "Designated Value" and `value` is a... "Value". 

I see from the YAML Guide that `target` is the objective's percentage target, and `value` is the threshold value, and that for ratio SLOs `value` is not used but must be unique across objectives for legacy reasons. (Computers, right?) 

So, here's a doc update that notes all of that in the Terraform instructions.

## Summary

Updates descriptions for `target` and `value` fields in `nobl9_slo` `objective`s and `composite`s.

## Related Changes

None.

## Testing

Doc change only.

