### PR TITLE
fix: Set ForceNew to true for service in SLO

### DIFF
--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -190,6 +190,7 @@ func schemaSLO() map[string]*schema.Schema {
 		"service": {
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 			Description: "Name of the service.",
 		},
 		"indicator": {


### PR DESCRIPTION
## Summary

Setting `ForceNew` will now display a warning both in plan and during apply.

![image](https://github.com/user-attachments/assets/b92f8fdf-58c0-43b7-937e-611cf490e4ac)

## Release Notes

`service` property in `nobl9_slo` resource is now causing a new resource to be created in place of the existing one if it was changed. It will now follow the same rule as `project` or `name` properties. The lack of such validation was an oversight and does not modify any existing Nobl9 platform rules.
