### PR TITLE
chore: Remove deprecated 'Subject' and 'Body' support from Email alert method.

### DIFF
--- a/docs/resources/alert_method_email.md
+++ b/docs/resources/alert_method_email.md
@@ -39,11 +39,9 @@ resource "nobl9_alert_method_email" "this" {
 ### Optional
 
 - `bcc` (List of String) Blind carbon copy recipients. The maximum number of recipients is 10.
-- `body` (String, Deprecated) This value was used as the template for the email alert's body. 'body' is deprecated and not used anywhere; however, its' kept for backward compatibility.
 - `cc` (List of String) Carbon copy recipients. The maximum number of recipients is 10.
 - `description` (String) Optional description of the resource. Here, you can add details about who is responsible for the integration (team/owner) or the purpose of creating it.
 - `display_name` (String) User-friendly display name of the resource.
-- `subject` (String, Deprecated) This value was used as the email alert's subject. 'subject' is deprecated and not used anywhere; however, its' kept for backward compatibility.
 
 ### Read-Only
 

--- a/nobl9/resource_alertmethod.go
+++ b/nobl9/resource_alertmethod.go
@@ -575,18 +575,6 @@ func (i alertMethodEmail) GetSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"subject": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Deprecated:  "'subject' indicated the email alert's subject. It has been deprecated since the Nobl9 1.57 release and is no longer used to generate emails. You can safely remove it from your configuration file.",
-			Description: "This value was used as the email alert's subject. 'subject' is deprecated and not used anywhere; however, its' kept for backward compatibility.",
-		},
-		"body": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Deprecated:  "'body' indicated the email alert's body. It has been deprecated since the Nobl9 1.57 release and is no longer used to generate emails. You can safely remove it from your configuration file.",
-			Description: "This value was used as the template for the email alert's body. 'body' is deprecated and not used anywhere; however, its' kept for backward compatibility.",
-		},
 	}
 }
 
@@ -594,11 +582,9 @@ func (i alertMethodEmail) MarshalSpec(r resourceInterface) v1alphaAlertMethod.Sp
 	return v1alphaAlertMethod.Spec{
 		Description: r.Get("description").(string),
 		Email: &v1alphaAlertMethod.EmailAlertMethod{
-			To:      toStringSlice(r.Get("to").([]interface{})),
-			Cc:      toStringSlice(r.Get("cc").([]interface{})),
-			Bcc:     toStringSlice(r.Get("bcc").([]interface{})),
-			Subject: r.Get("subject").(string),
-			Body:    r.Get("body").(string),
+			To:  toStringSlice(r.Get("to").([]interface{})),
+			Cc:  toStringSlice(r.Get("cc").([]interface{})),
+			Bcc: toStringSlice(r.Get("bcc").([]interface{})),
 		},
 	}
 }
@@ -612,12 +598,6 @@ func (i alertMethodEmail) UnmarshalSpec(d *schema.ResourceData, spec v1alphaAler
 	err = d.Set("cc", config.Cc)
 	diags = appendError(diags, err)
 	err = d.Set("bcc", config.Bcc)
-	diags = appendError(diags, err)
-	//nolint:staticcheck
-	err = d.Set("subject", config.Subject)
-	diags = appendError(diags, err)
-	//nolint:staticcheck
-	err = d.Set("body", config.Body)
 	diags = appendError(diags, err)
 
 	return diags

--- a/nobl9/resource_alertmethod_test.go
+++ b/nobl9/resource_alertmethod_test.go
@@ -27,7 +27,6 @@ func TestAcc_Nobl9AlertMethod(t *testing.T) {
 		{"test-jira", "jira", testJiraConfig},
 		{"test-teams", "msteams", testTeamsConfig},
 		{"test-email", "email", testEmailConfig},
-		{"test-email-no-subject-and-body", "email", testEmailConfigWithoutSubjectAndBody},
 	}
 
 	for _, tc := range cases {
@@ -183,21 +182,6 @@ resource "nobl9_alert_method_msteams" "%s" {
 }
 
 func testEmailConfig(name string) string {
-	return fmt.Sprintf(`
-resource "nobl9_alert_method_email" "%s" {
-  name        = "%s"
-  project     = "%s"
-  description = "teams"
-  to		  = [ "testUser@nobl9.com" ]
-  cc		  = [ "testUser@nobl9.com" ]
-  bcc		  = [ "testUser@nobl9.com" ]
-  subject     = "Test email please ignore"
-  body        = "This is just a test email"
-}
-`, name, name, testProject)
-}
-
-func testEmailConfigWithoutSubjectAndBody(name string) string {
 	return fmt.Sprintf(`
 resource "nobl9_alert_method_email" "%s" {
   name        = "%s"


### PR DESCRIPTION
## Motivation

Removed deprecated fields `Subject` and `Body` for Email alert method.

## Summary

Fields were marked as deprecated in 2024 July ( https://github.com/nobl9/terraform-provider-nobl9/releases/tag/v0.14.0  ) and were ignored by API since then.

## Related Changes

- Upcoming SDK version https://github.com/nobl9/nobl9-go/releases/tag/v0.91.0-rc3

## Testing

- Passing [acceptance tests](https://github.com/nobl9/terraform-provider-nobl9/actions/runs/12137243789/job/33840060050) for alert methods ✅ 
![image](https://github.com/user-attachments/assets/66634e6a-2ef8-4775-adc4-447e67e0974a)
- Passing `make test/unit` ✅ 
- Manual test ✅ 
```terraform
terraform {
  required_providers {
    nobl9 = {
      source = "nobl9.com/nobl9/nobl9"
      version = "0.32.2"
    }
  }
}

provider "nobl9" {
  client_id = ""
  client_secret = ""
  okta_org_url     = ""
  okta_auth_server = ""
}

resource "nobl9_project" "this" {
  display_name = "Test N9 Terraform"
  name         = "test-n9-terraform"
}

resource "nobl9_alert_method_email" "this" {
  name         = "my-email-alert"
  display_name = "My Email Alert"
  project      = nobl9_project.this.name
  description = "email"
  to		  = [ "testUser@nobl9.com" ]
  cc		  = [ "testUser@nobl9.com" ]
  bcc		  = [ "testUser@nobl9.com" ]
}
```
Result:
![image](https://github.com/user-attachments/assets/5bd6a32d-5d8b-4d16-afd9-0da3d4a7ce15)

When I pass `Subject` or `Body` I can see error:
```terraform
resource "nobl9_alert_method_email" "this" {
  name         = "my-email-alert"
  display_name = "My Email Alert"
  project      = nobl9_project.this.name
  description = "email"
  to		  = [ "testUser@nobl9.com" ]
  cc		  = [ "testUser@nobl9.com" ]
  bcc		  = [ "testUser@nobl9.com" ]
  subject = "Test Email Alert"
  body = "This is a test email alert"
}
```
Result:
![image](https://github.com/user-attachments/assets/e70c4a58-1b3d-4d73-9b1f-747fb2524715)

## Breaking Changes

Removed deprecated fields `Subject` and `Body` for Email alert method.