### PR TITLE
chore: Bump go version to 1.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/terraform-provider-nobl9
 
-go 1.23.4
+go 1.23
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/terraform-provider-nobl9
 
-go 1.22
+go 1.23.4
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Motivation

I am manually bumping go version to the newest available to avoid issue with renovate failing to install `govulncheck` tool:
https://github.com/nobl9/terraform-provider-nobl9/actions/runs/12235599079/job/34127224087

The issue comes probably from `actions/setup-go` always configuring version of go coming from `go` directive. It seems that version declared in `toolchain` is also installed but there are a bunch of warning reported so I am assuming something is wrong with that step. `toolchain` directive is added and by Renovate. Bumping `go` directive is now disabled by default.  I don't know why exactly it stops working as setting different `toolchain` should be forward-compatible but here we are.

## Summary

Bump go version to `1.23.4`

## Related Changes

https://github.com/nobl9/terraform-provider-nobl9/pull/336
https://github.com/renovatebot/renovate/issues/24427
https://github.com/renovatebot/renovate/issues/16715
