### PR TITLE
chore: Update value description

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -237,7 +237,7 @@ Optional:
 - `primary` (Boolean) Is objective marked as primary.
 - `raw_metric` (Block Set) Raw data is used to compare objective values. (see [below for nested schema](#nestedblock--objective--raw_metric))
 - `time_slice_target` (Number) Designated value for slice.
-- `value` (Number) Required for threshold and ratio metrics. Optional for composite SLOs. For thresholdmetrics, the threshold value. For ratio metrics, for legacy reasons, this must be a unique valueper objective. For composite SLOs it should be omitted. If, for composite SLO, it was setpreviously to a non zero value then it should remain set to that value.
+- `value` (Number) Required for threshold and ratio metrics. Optional for composite SLOs. For threshold metrics, the threshold value. For ratio metrics, for legacy reasons, this must be a unique value per objective. For composite SLOs it should be omitted. If, for composite SLO, it was set previously to a non zero value then it should remain set to that value.
 
 <a id="nestedblock--objective--composite"></a>
 ### Nested Schema for `objective.composite`

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -237,7 +237,7 @@ Optional:
 - `primary` (Boolean) Is objective marked as primary.
 - `raw_metric` (Block Set) Raw data is used to compare objective values. (see [below for nested schema](#nestedblock--objective--raw_metric))
 - `time_slice_target` (Number) Designated value for slice.
-- `value` (Number) Required for threshold and ratio metrics. Optional for composite SLOs. For threshold metrics, the threshold value. For ratio metrics, for legacy reasons, this must be a unique value per objective. For composite SLOs it should be omitted. If, for composite SLO, it was set previously to a non zero value then it should remain set to that value.
+- `value` (Number) Required for threshold and ratio metrics. Optional for composite SLOs. For threshold metrics, the threshold value. For ratio metrics, this must be a unique value per objective (for legacy reasons). For composite SLOs, it should be omitted. If, for composite SLO, it was set previously to a non-zero value, then it must remain unchanged.
 
 <a id="nestedblock--objective--composite"></a>
 ### Nested Schema for `objective.composite`

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -152,9 +152,9 @@ func resourceObjective() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Optional: true,
 				Description: "Required for threshold and ratio metrics. Optional for composite SLOs. For threshold" +
-					"metrics, the threshold value. For ratio metrics, for legacy reasons, this must be a unique value" +
-					"per objective. For composite SLOs it should be omitted. If, for composite SLO, it was set" +
-					"previously to a non zero value then it should remain set to that value.",
+					" metrics, the threshold value. For ratio metrics, for legacy reasons, this must be a unique value" +
+					" per objective. For composite SLOs it should be omitted. If, for composite SLO, it was set" +
+					" previously to a non zero value then it should remain set to that value.",
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/nobl9/resource_slo.go
+++ b/nobl9/resource_slo.go
@@ -152,9 +152,9 @@ func resourceObjective() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Optional: true,
 				Description: "Required for threshold and ratio metrics. Optional for composite SLOs. For threshold" +
-					" metrics, the threshold value. For ratio metrics, for legacy reasons, this must be a unique value" +
-					" per objective. For composite SLOs it should be omitted. If, for composite SLO, it was set" +
-					" previously to a non zero value then it should remain set to that value.",
+					" metrics, the threshold value. For ratio metrics, this must be a unique value per objective (for" +
+					" legacy reasons). For composite SLOs, it should be omitted. If, for composite SLO, it was set" +
+					" previously to a non-zero value, then it must remain unchanged.",
 			},
 			"name": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
This PR corrects formatting (missing spaces) in the description of the `value` field for the `nobl9_slo` resource.