### PR TITLE
feat: Add custom headers support for Webhook AlertMethod

### DIFF
--- a/docs/resources/alert_method_webhook.md
+++ b/docs/resources/alert_method_webhook.md
@@ -58,7 +58,7 @@ resource "nobl9_alert_method_webhook" "this" {
 - `description` (String) Optional description of the resource. Here, you can add details about who is responsible for the integration (team/owner) or the purpose of creating it.
 - `display_name` (String) User-friendly display name of the resource.
 - `headers` (Map of String) Custom HTTP headers to include in the webhook request.
-- `sensitive_headers` (Map of String, Sensitive) Custom HTTP headers to include in the webhook request. The values are treated as sensitive, will not be displayed in the Terraform state and will be encrypted at the Nobl9.
+- `sensitive_headers` (Map of String, Sensitive) Custom HTTP headers to include in the webhook request. The values are treated as sensitive, will not be displayed in the Terraform state and will be encrypted by Nobl9 platform.
 - `template` (String) Webhook message template. See documentation for template format and samples.
 - `template_fields` (List of String) Webhook message fields. The message contains JSON payload with specified fields. See documentation for allowed fields.
 - `url` (String, Sensitive) URL of the webhook endpoint.

--- a/docs/resources/alert_method_webhook.md
+++ b/docs/resources/alert_method_webhook.md
@@ -57,6 +57,8 @@ resource "nobl9_alert_method_webhook" "this" {
 
 - `description` (String) Optional description of the resource. Here, you can add details about who is responsible for the integration (team/owner) or the purpose of creating it.
 - `display_name` (String) User-friendly display name of the resource.
+- `headers` (Map of String) Custom HTTP headers to include in the webhook request.
+- `sensitive_headers` (Map of String, Sensitive) Custom HTTP headers to include in the webhook request. The values are treated as sensitive, will not be displayed in the Terraform state and will be encrypted at the Nobl9.
 - `template` (String) Webhook message template. See documentation for template format and samples.
 - `template_fields` (List of String) Webhook message fields. The message contains JSON payload with specified fields. See documentation for allowed fields.
 - `url` (String, Sensitive) URL of the webhook endpoint.

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
-	github.com/MicahParks/jwkset v0.5.20 // indirect
+	github.com/MicahParks/jwkset v0.7.0 // indirect
 	github.com/MicahParks/keyfunc/v3 v3.3.5 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
@@ -92,7 +92,7 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	golang.org/x/time v0.8.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/MicahParks/jwkset v0.5.20 h1:gTIKx9AofTqQJ0srd8AL7ty9NeadP5WUXSPOZadTpOI=
 github.com/MicahParks/jwkset v0.5.20/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
+github.com/MicahParks/jwkset v0.7.0 h1:CXWuiYBk5NuTl+N/3UI3UcYNH79yWuKAZWZkc/y+7Ok=
+github.com/MicahParks/jwkset v0.7.0/go.mod h1:fVrj6TmG1aKlJEeceAz7JsXGTXEn72zP1px3us53JrA=
 github.com/MicahParks/keyfunc/v3 v3.3.5 h1:7ceAJLUAldnoueHDNzF8Bx06oVcQ5CfJnYwNt1U3YYo=
 github.com/MicahParks/keyfunc/v3 v3.3.5/go.mod h1:SdCCyMJn/bYqWDvARspC6nCT8Sk74MjuAY22C7dCST8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -307,6 +309,8 @@ golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
 golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=

--- a/nobl9/resource_alertmethod.go
+++ b/nobl9/resource_alertmethod.go
@@ -202,7 +202,7 @@ func (i alertMethodWebhook) GetSchema() map[string]*schema.Schema {
 			Optional:  true,
 			Sensitive: true,
 			// nolint:lll
-			Description: "Custom HTTP headers to include in the webhook request. The values are treated as sensitive, will not be displayed in the Terraform state and will be encrypted at the Nobl9.",
+			Description: "Custom HTTP headers to include in the webhook request. The values are treated as sensitive, will not be displayed in the Terraform state and will be encrypted by Nobl9 platform.",
 		},
 	}
 }

--- a/nobl9/resource_alertmethod.go
+++ b/nobl9/resource_alertmethod.go
@@ -190,6 +190,20 @@ func (i alertMethodWebhook) GetSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"headers": {
+			Type:        schema.TypeMap,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: "Custom HTTP headers to include in the webhook request.",
+		},
+		"sensitive_headers": {
+			Type:      schema.TypeMap,
+			Elem:      &schema.Schema{Type: schema.TypeString},
+			Optional:  true,
+			Sensitive: true,
+			// nolint:lll
+			Description: "Custom HTTP headers to include in the webhook request. The values are treated as sensitive, will not be displayed in the Terraform state and will be encrypted at the Nobl9.",
+		},
 	}
 }
 
@@ -205,12 +219,31 @@ func (i alertMethodWebhook) MarshalSpec(r resourceInterface) v1alphaAlertMethod.
 		templateFields = nil
 	}
 
+	headers := make([]v1alphaAlertMethod.WebhookHeader, 0)
+	for key, value := range r.Get("headers").(map[string]interface{}) {
+		header := v1alphaAlertMethod.WebhookHeader{
+			Name:     key,
+			Value:    value.(string),
+			IsSecret: false,
+		}
+		headers = append(headers, header)
+	}
+	for key, value := range r.Get("sensitive_headers").(map[string]interface{}) {
+		header := v1alphaAlertMethod.WebhookHeader{
+			Name:     key,
+			Value:    value.(string),
+			IsSecret: true,
+		}
+		headers = append(headers, header)
+	}
+
 	return v1alphaAlertMethod.Spec{
 		Description: r.Get("description").(string),
 		Webhook: &v1alphaAlertMethod.WebhookAlertMethod{
 			URL:            r.Get("url").(string),
 			Template:       template,
 			TemplateFields: templateFields,
+			Headers:        headers,
 		},
 	}
 }
@@ -222,6 +255,17 @@ func (i alertMethodWebhook) UnmarshalSpec(d *schema.ResourceData, spec v1alphaAl
 	err := d.Set("template", config.Template)
 	diags = appendError(diags, err)
 	err = d.Set("template_fields", config.TemplateFields)
+	diags = appendError(diags, err)
+
+	headers := make(map[string]interface{})
+
+	for _, header := range config.Headers {
+		if !header.IsSecret { // secrets will be returned from the API as [hidden] values
+			headers[header.Name] = header.Value
+		}
+	}
+
+	err = d.Set("headers", headers)
 	diags = appendError(diags, err)
 
 	return diags

--- a/nobl9/resource_alertmethod_test.go
+++ b/nobl9/resource_alertmethod_test.go
@@ -17,6 +17,7 @@ func TestAcc_Nobl9AlertMethod(t *testing.T) {
 	}{
 		{"test-webhook", "webhook", testWebhookTemplateConfig},
 		{"test-webhook-fields", "webhook", testWebhookTemplateFieldsConfig},
+		{"test-webhook-headers", "webhook", testWebhookHeadersConfig},
 		{"test-pagerduty", "pagerduty", testPagerDutyConfig},
 		{"test-pagerduty-send-resolution", "pagerduty", testPagerDutyWithSendResolutionConfig},
 		{"test-pagerduty-send-resolution-message", "pagerduty", testPagerDutyWithSendResolutionWithMessageConfig},
@@ -68,6 +69,24 @@ resource "nobl9_alert_method_webhook" "%s" {
   description	  = "WebHook"
   url             = "http://web.net"
   template_fields = [ "slo_name", "slo_details_link" ]
+}
+`, name, name, testProject)
+}
+
+func testWebhookHeadersConfig(name string) string {
+	return fmt.Sprintf(`
+resource "nobl9_alert_method_webhook" "%s" {
+  name            = "%s"
+  project         = "%s"
+  description	    = "WebHook"
+  url             = "http://web.net"
+  template        = "SLO needs attention $slo_name"
+  headers         = {
+    "X-Custom-Header" = "custom value"
+  }
+  sensitive_headers = {
+    "Authorization" = "Bearer xyz"
+  }
 }
 `, name, name, testProject)
 }


### PR DESCRIPTION
## Motivation

Webhook alert method does not support custom HTTP headers now.

## Summary

- the headers in .tf are split into `headers` and `sensitive_headers` to allow settings secrets..

```
resource "nobl9_alert_method_webhook" "webhook" {
  name            = "webhook"
  project         = "default"
  url             = "http://web.net"
  template        = "SLO needs attention $slo_name"
  headers         = {
    "X-Custom-Header" = "custom value"
  }
  sensitive_headers = {
    "Authorization" = "Bearer xyz"
  }
}
```

## Release Notes

Webhook alert method now supports custom HTTP headers.