### PR TITLE
chore: Update broken link for webhook

### DIFF
--- a/docs/resources/alert_method_webhook.md
+++ b/docs/resources/alert_method_webhook.md
@@ -9,7 +9,7 @@ description: |-
 
 The **Webhook Alert Method** enables sending alerts through an HTTP callback handler that is triggered by an event. You can create webhooks and configure them to handle different incident notifications, using either custom or predefined notification templates.
 
--> **NOTE** For details on how to use Webhook message templates, check the [Nobl9 documentation](https://docs.nobl9.com/alerting/webhook#creating-webhook-custom-templates-through-yaml).
+-> **NOTE** For details on how to use Webhook message templates, check the [Nobl9 documentation](https://docs.nobl9.com/alerting/alert-methods/webhook#creating-webhook-custom-templates-through-yaml).
 
 For more details, refer to [Webhook Alert Method | Nobl9 Documentation](https://docs.nobl9.com/alerting/alert-methods/webhook).
 

--- a/templates/resources/alert_method_webhook.md.tmpl
+++ b/templates/resources/alert_method_webhook.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 The **Webhook Alert Method** enables sending alerts through an HTTP callback handler that is triggered by an event. You can create webhooks and configure them to handle different incident notifications, using either custom or predefined notification templates.
 
--> **NOTE** For details on how to use Webhook message templates, check the [Nobl9 documentation](https://docs.nobl9.com/alerting/webhook#creating-webhook-custom-templates-through-yaml).
+-> **NOTE** For details on how to use Webhook message templates, check the [Nobl9 documentation](https://docs.nobl9.com/alerting/alert-methods/webhook#creating-webhook-custom-templates-through-yaml).
 
 For more details, refer to {{ .Description | trimspace }}.
 


### PR DESCRIPTION
This PR updates a broken link to the main Nobl9 documentation for the Webhook alert method.