### PR TITLE
fix: PC-9592 Update opsgenie, slack URLs in tests

### DIFF
--- a/docs/resources/alert_method_slack.md
+++ b/docs/resources/alert_method_slack.md
@@ -23,7 +23,7 @@ resource "nobl9_alert_method_slack" "this" {
   display_name = "My Slack Alert"
   project      = "Test Project"
   description = "slack"
-  url         = "https://slack.com"
+  url         = "https://hooks.slack.com/services/321/123/secret"
 }
 ```
 

--- a/docs/resources/alert_method_slack.md
+++ b/docs/resources/alert_method_slack.md
@@ -22,8 +22,8 @@ resource "nobl9_alert_method_slack" "this" {
   name         = "my-slack-alert"
   display_name = "My Slack Alert"
   project      = "Test Project"
-  description = "slack"
-  url         = "https://hooks.slack.com/services/321/123/secret"
+  description  = "slack"
+  url          = "https://hooks.slack.com/services/321/123/secret"
 }
 ```
 

--- a/examples/resources/nobl9_alert_method_slack/resource.tf
+++ b/examples/resources/nobl9_alert_method_slack/resource.tf
@@ -2,7 +2,7 @@ resource "nobl9_alert_method_slack" "this" {
   name         = "my-slack-alert"
   display_name = "My Slack Alert"
   project      = "Test Project"
-  description = "slack"
-  url         = "https://slack.com"
+  description  = "slack"
+  url          = "https://hooks.slack.com/services/321/123/secret"
 }
 

--- a/nobl9/resource_alert_policy_test.go
+++ b/nobl9/resource_alert_policy_test.go
@@ -94,19 +94,19 @@ func TestAcc_Nobl9AlertPolicy(t *testing.T) {
 				name        = "%s"
 				project     = "%s"
 				description = "slack"
-				url         = "https://slack.com"
+				url         = "https://hooks.slack.com/services/321/123/secret"
 			}
 			resource "nobl9_alert_method_slack" "%s" {
 				name        = "%s"
 				project     = "%s"
 				description = "slack"
-				url         = "https://slack.com"
+				url         = "https://hooks.slack.com/services/321/123/secret"
 			}
 			resource "nobl9_alert_method_slack" "%s" {
 				name        = "%s"
 				project     = "%s"
 				description = "slack"
-				url         = "https://slack.com"
+				url         = "https://hooks.slack.com/services/321/123/secret"
 			}
 			`,
 				"am1", "am1", testProject,
@@ -134,19 +134,19 @@ func TestAcc_Nobl9AlertPolicy(t *testing.T) {
 				name        = "%s"
 				project     = "%s"
 				description = "slack"
-				url         = "https://slack.com"
+				url         = "https://hooks.slack.com/services/321/123/secret"
 			}
 			resource "nobl9_alert_method_slack" "%s" {
 				name        = "%s"
 				project     = "%s"
 				description = "slack"
-				url         = "https://slack.com"
+				url         = "https://hooks.slack.com/services/321/123/secret"
 			}
 			resource "nobl9_alert_method_slack" "%s" {
 				name        = "%s"
 				project     = "%s"
 				description = "slack"
-				url         = "https://slack.com"
+				url         = "https://hooks.slack.com/services/321/123/secret"
 			}
 			`,
 				"am1", "am1", testProject,

--- a/nobl9/resource_alertmethod_test.go
+++ b/nobl9/resource_alertmethod_test.go
@@ -137,7 +137,7 @@ resource "nobl9_alert_method_slack" "%s" {
   name        = "%s"
   project     = "%s"
   description = "slack"
-  url         = "https://slack.com"
+  url         = "https://hooks.slack.com/services/321/123/secret"
 }
 `, name, name, testProject)
 }
@@ -159,7 +159,7 @@ resource "nobl9_alert_method_opsgenie" "%s" {
   name        = "%s"
   project     = "%s"
   description = "opsgenie"
-  url         = "https://discord.com"
+  url         = "https://api.opsgenie.com"
   auth		  = "GenieKey 12345"
 }
 `, name, name, testProject)
@@ -222,7 +222,7 @@ resource "nobl9_alert_method_slack" "%s" {
   name        = "%s"
   project     = "%s"
   description = "slack"
-  url         = "https://slack.com"
+  url         = "https://hooks.slack.com/services/321/123/secret"
 }
 `, name, name, project)
 }


### PR DESCRIPTION
## Motivation

Fix failing Terraform Acceptance tests

## Summary

* Updated invalid URLs for slack and opsgenie alert methods.

## Testing

* https://github.com/nobl9/terraform-provider-nobl9/actions/runs/12808258859/job/35710591061

## Release Notes

