### PR TITLE
chore: fix message error in test that validates metrics.

### DIFF
--- a/nobl9/resource_slo_test.go
+++ b/nobl9/resource_slo_test.go
@@ -97,7 +97,7 @@ func TestAcc_Nobl9SLOErrors(t *testing.T) {
 		},
 		{"test-metric-spec-required",
 			testMetricSpecRequired,
-			`At least 1 "total" blocks are required`,
+			`one of \[goodTotal, total\] properties must be set, none was provided`,
 		},
 		{"test-more-than-one-primary-objective",
 			testMoreThanOnePrimaryObjective,


### PR DESCRIPTION
The validation message in nobl9-sdk changed after we introduced a single query.

