### PR TITLE
chore: Bump version of TF provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAMESPACE = nobl9
 NAME = nobl9
 BIN_DIR = ./bin
 BINARY = $(BIN_DIR)/terraform-provider-$(NAME)
-VERSION = 0.37.0
+VERSION = 0.37.1
 LDFLAGS += -X main.Version=$(VERSION)
 OS_ARCH := $(shell go env GOOS)_$(shell go env GOARCH)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     nobl9 = {
       source = "nobl9/nobl9"
-      version = "0.37.0"
+      version = "0.37.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.37.0"
+      version = "0.37.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nobl9 = {
       source  = "nobl9/nobl9"
-      version = "0.37.0"
+      version = "0.37.1"
     }
   }
 }


### PR DESCRIPTION
### Summary
This pull request includes a version update for the `nobl9` provider from `0.37.0` to `0.37.1` across multiple files. The changes ensure the documentation and example configurations are consistent with the new version that's planned to release.