### PR TITLE
chore: Update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,8 +53,9 @@ signs:
       - "${artifact}"
 release:
   make_latest: false
+  draft: true
+  replace_existing_draft: false
+  prerelease: auto
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true


### PR DESCRIPTION
## Motivation

Recent changes to the Goreleaser started breaking our release process which involves creating pre-release versions. These releases are marked by us as pre-release and contain `-rc` suffix. Unfortunately Goreleaser started removing pre-release flag from them when publishing artifacts.
This PR fixes it.

## Related Changes

https://github.com/nobl9/sloctl/pull/304