### PR TITLE
chore: Allow to cache token during acceptance tests run

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -53,3 +53,4 @@ jobs:
           TERRAFORM_NOBL9_OKTA_ORG_URL: "${{ inputs.oktaOrgUrl }}"
           TERRAFORM_NOBL9_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
           TERRAFORM_NOBL9_PROJECT: "${{ inputs.project }}"
+          TERRAFORM_NOBL9_NO_CONFIG_FILE: false

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -50,8 +50,7 @@ jobs:
         env:
           NOBL9_CLIENT_ID: "${{ inputs.clientId }}"
           NOBL9_CLIENT_SECRET: "${{ secrets.clientSecret }}"
-          TERRAFORM_NOBL9_OKTA_ORG_URL: "${{ inputs.oktaOrgUrl }}"
-          TERRAFORM_NOBL9_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
-          TERRAFORM_NOBL9_PROJECT: "${{ inputs.project }}"
-          TERRAFORM_NOBL9_NO_CONFIG_FILE: false
+          NOBL9_OKTA_ORG_URL: "${{ inputs.oktaOrgUrl }}"
+          NOBL9_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
+          NOBL9_PROJECT: "${{ inputs.project }}"
           NOBL9_NO_CONFIG_FILE: false

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -54,3 +54,4 @@ jobs:
           TERRAFORM_NOBL9_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
           TERRAFORM_NOBL9_PROJECT: "${{ inputs.project }}"
           TERRAFORM_NOBL9_NO_CONFIG_FILE: false
+          NOBL9_NO_CONFIG_FILE: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,11 +57,11 @@ provider "nobl9" {
 - `client_id` (String) The [Client ID](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.
 - `client_secret` (String, Sensitive) The [Client Secret](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.
 - `ingest_url` (String) Nobl9 API URL.
+- `no_config_file` (Boolean) Disable reading configuration from file.
 - `okta_auth_server` (String) Authorization service configuration.
 - `okta_org_url` (String) Authorization service URL.
 - `organization` (String) Nobl9 Organization ID that contains resources managed by the provider.
 - `project` (String) Nobl9 project used when importing resources.
-- `no_config_file` (Boolean) Disable reading configuration from file.
 
 ## Useful Links
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ provider "nobl9" {
 - `okta_org_url` (String) Authorization service URL.
 - `organization` (String) Nobl9 Organization ID that contains resources managed by the provider.
 - `project` (String) Nobl9 project used when importing resources.
-- `no_config_file` (Bool) Disable reading configuration from file.
+- `no_config_file` (Boolean) Disable reading configuration from file.
 
 ## Useful Links
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ provider "nobl9" {
 - `okta_org_url` (String) Authorization service URL.
 - `organization` (String) Nobl9 Organization ID that contains resources managed by the provider.
 - `project` (String) Nobl9 project used when importing resources.
+- `no_config_file` (Bool) Disable reading configuration from file.
 
 ## Useful Links
 

--- a/internal/frameworkprovider/env_configurable_bool.go
+++ b/internal/frameworkprovider/env_configurable_bool.go
@@ -1,0 +1,42 @@
+package frameworkprovider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.BoolValuable = envConfigurableBool{}
+	_ basetypes.BoolTypable  = envConfigurableBoolType{}
+)
+
+type envConfigurableBool struct{ basetypes.BoolValue }
+
+// Decode implements [envconfig.Decoder] interface.
+func (e *envConfigurableBool) Decode(value string) error {
+	boolValue, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	e.BoolValue = basetypes.NewBoolValue(boolValue)
+	return nil
+}
+
+type envConfigurableBoolType struct{ basetypes.BoolType }
+
+func (t envConfigurableBoolType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	v, err := t.BoolType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	sv, ok := v.(basetypes.BoolValue)
+	if !ok {
+		return nil, fmt.Errorf("expected %T to return a %T", t.BoolType, basetypes.BoolValue{})
+	}
+	return envConfigurableBool{sv}, nil
+}

--- a/internal/frameworkprovider/provider.go
+++ b/internal/frameworkprovider/provider.go
@@ -71,6 +71,11 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 				Description: "Nobl9 API URL.",
 				CustomType:  envConfigurableStringType{},
 			},
+			"no_config_file": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Disable reading configuration from file.",
+				CustomType:  envConfigurableBoolType{},
+			},
 		},
 	}
 }

--- a/internal/frameworkprovider/provider_model.go
+++ b/internal/frameworkprovider/provider_model.go
@@ -15,6 +15,7 @@ type ProviderModel struct {
 	Project        envConfigurableString `tfsdk:"project"          envconfig:"PROJECT"`
 	IngestURL      envConfigurableString `tfsdk:"ingest_url"       envconfig:"URL"`
 	Organization   envConfigurableString `tfsdk:"organization"     envconfig:"ORG"`
+	NoConfigFile   envConfigurableBool   `tfsdk:"no_config_file"   envconfig:"NO_CONFIG_FILE" default:"true"`
 }
 
 // setDefaultsFromEnv sets the default values for the [ProviderModel] from the
@@ -48,6 +49,9 @@ func (p *ProviderModel) setDefaultsFromEnv() diag.Diagnostics {
 	}
 	if p.Organization.IsNull() {
 		p.Organization = env.Organization
+	}
+	if p.NoConfigFile.IsNull() {
+		p.NoConfigFile = env.NoConfigFile
 	}
 	return nil
 }

--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -24,7 +24,6 @@ type sdkClient struct {
 func newSDKClient(provider ProviderModel, version string) (*sdkClient, diag.Diagnostics) {
 	options := []sdk.ConfigOption{
 		sdk.ConfigOptionWithCredentials(provider.ClientID.ValueString(), provider.ClientSecret.ValueString()),
-		sdk.ConfigOptionNoConfigFile(),
 		sdk.ConfigOptionEnvPrefix("TERRAFORM_NOBL9_"),
 	}
 	sdkConfig, err := sdk.ReadConfig(options...)

--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -26,6 +26,9 @@ func newSDKClient(provider ProviderModel, version string) (*sdkClient, diag.Diag
 		sdk.ConfigOptionWithCredentials(provider.ClientID.ValueString(), provider.ClientSecret.ValueString()),
 		sdk.ConfigOptionEnvPrefix("TERRAFORM_NOBL9_"),
 	}
+	if provider.NoConfigFile.ValueBool() {
+		options = append(options, sdk.ConfigOptionNoConfigFile())
+	}
 	sdkConfig, err := sdk.ReadConfig(options...)
 	if err != nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("failed to read Nobl9 SDK configuration", err.Error())}

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -164,8 +164,10 @@ func getClient(providerConfig ProviderConfig) (*sdk.Client, diag.Diagnostics) {
 			sdk.ConfigOptionEnvPrefix("TERRAFORM_NOBL9_"),
 		}
 		if providerConfig.NoConfigFile {
+			println("No config file option")
 			options = append(options, sdk.ConfigOptionNoConfigFile())
 		}
+		println("-- further step -- ")
 
 		sdkConfig, err := sdk.ReadConfig(options...)
 		if err != nil {

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -164,10 +164,8 @@ func getClient(providerConfig ProviderConfig) (*sdk.Client, diag.Diagnostics) {
 			sdk.ConfigOptionEnvPrefix("TERRAFORM_NOBL9_"),
 		}
 		if providerConfig.NoConfigFile {
-			println("No config file option")
 			options = append(options, sdk.ConfigOptionNoConfigFile())
 		}
-		println("-- further step -- ")
 
 		sdkConfig, err := sdk.ReadConfig(options...)
 		if err != nil {


### PR DESCRIPTION
## Motivation

The sdk client couldn't use token between tests. Removing the sdk.ConfigOptionNoConfigFile() option regarding the dedicated environment variable, allowed to store token in config file and use it in further test requests.