### PR TITLE
feat: Move away from proto v5 to v6

### DIFF
--- a/internal/frameworkprovider/project_data_source_test.go
+++ b/internal/frameworkprovider/project_data_source_test.go
@@ -47,7 +47,7 @@ func TestAccProjectDataSource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create Service resource with Project Data Source.
 			{

--- a/internal/frameworkprovider/project_resource_test.go
+++ b/internal/frameworkprovider/project_resource_test.go
@@ -49,7 +49,7 @@ func TestAccProjectResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read.
 			{

--- a/internal/frameworkprovider/service_data_source_test.go
+++ b/internal/frameworkprovider/service_data_source_test.go
@@ -57,7 +57,7 @@ func TestAccServiceDataSource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create Service resource with Service Data Source name in another Project.
 			{

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -54,7 +54,7 @@ func TestAccServiceResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read.
 			{

--- a/main.go
+++ b/main.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/nobl9/terraform-provider-nobl9/internal/frameworkprovider"
@@ -31,7 +33,7 @@ func main() {
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	muxServer, err := tf5muxserver.NewMuxServer(
+	muxServer, err := tf6muxserver.NewMuxServer(
 		ctx,
 		newSDKProvider(Version),
 		newFrameworkProvider(Version),
@@ -40,14 +42,14 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var serveOpts []tf5server.ServeOpt
+	var serveOpts []tf6server.ServeOpt
 	name := "registry.terraform.io/nobl9/nobl9"
 	if debugMode {
 		name = "nobl9.com/nobl9/nobl9"
-		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
+		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}
 
-	if err = tf5server.Serve(
+	if err = tf6server.Serve(
 		name,
 		muxServer.ProviderServer,
 		serveOpts...,
@@ -56,13 +58,16 @@ func main() {
 	}
 }
 
-func newSDKProvider(version string) func() tfprotov5.ProviderServer {
-	return func() tfprotov5.ProviderServer {
-		return schema.NewGRPCProviderServer(nobl9.Provider(version))
+func newSDKProvider(version string) func() tfprotov6.ProviderServer {
+	return func() tfprotov6.ProviderServer {
+		srv, _ := tf5to6server.UpgradeServer(nil, func() tfprotov5.ProviderServer {
+			return schema.NewGRPCProviderServer(nobl9.Provider(version))
+		})
+		return srv
 	}
 }
 
-func newFrameworkProvider(version string) func() tfprotov5.ProviderServer {
+func newFrameworkProvider(version string) func() tfprotov6.ProviderServer {
 	provider := frameworkprovider.New(version)
-	return providerserver.NewProtocol5(provider)
+	return providerserver.NewProtocol6(provider)
 }

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "metadata": {
-    "protocol_versions": ["5.0"]
+    "protocol_versions": ["6.0"]
   }
 }


### PR DESCRIPTION
## Motivation

This step is necessary to use attribute blocks in the new framework provider, otherwise we need do dirty hacks to represent optional blocks as lists.

The change will not work with Terraform below version 0.15 as these do not support v6.

Terraform version 0.15.0 was released on April 14, 2021 and it is now 4+ years old, chances anyone still uses it are low, and even If they should long have updated it.

## Summary

https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux/tf5to6server package has been used to translate the old SDK v2 proto v5 to v6.

## Related Changes

https://github.com/nobl9/terraform-provider-nobl9/pull/455

## Testing

Passing acceptance tests:

## Breaking Changes

Terraform versions below 0.15 **WILL NO LONGER WORK** with Nobl9 Provider. Please update your Terraform version in order to continue using it.