### PR TITLE
fix: Empty AlertPolicies list in SLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 # Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) 0.10.x
+- [Terraform](https://www.terraform.io/downloads.html) 0.15.x
 
 # Example
 

--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,11 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/nobl9/nobl9-go v0.113.0
+	github.com/nobl9/nobl9-go v0.115.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2
 )
-
-replace github.com/nobl9/nobl9-go => github.com/nobl9/nobl9-go v0.113.0-rc1.0.20250904110154-e88d75c969cf
 
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/nobl9/govy v0.20.0 h1:8BV2ko3OJLFWYa0K9GDwt9oKllax9yOaSAj3PUqfXC0=
 github.com/nobl9/govy v0.20.0/go.mod h1:DN0zA5jtaHrb+uKPATycrlr7HRJy27QUaUg8LEeTsxo=
-github.com/nobl9/nobl9-go v0.113.0-rc1.0.20250904110154-e88d75c969cf h1:Pj9tATYTzOcPCOiZD8UqwBwUc9zpQtu3iJ15Zynnb5g=
-github.com/nobl9/nobl9-go v0.113.0-rc1.0.20250904110154-e88d75c969cf/go.mod h1:/t4DLBsxm1jKTeG/1zQ61y+C1Sivf5sfzs7X8t4UFvI=
+github.com/nobl9/nobl9-go v0.115.0 h1:TNCle3bLt7ZLPPMvv6ZhmQOcafWGisCleMwV8GXDCNg=
+github.com/nobl9/nobl9-go v0.115.0/go.mod h1:/t4DLBsxm1jKTeG/1zQ61y+C1Sivf5sfzs7X8t4UFvI=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/frameworkprovider/provider_test.go
+++ b/internal/frameworkprovider/provider_test.go
@@ -192,6 +192,17 @@ func getObjectsFromTheNobl9API(t *testing.T, ctx context.Context, object manifes
 	if !assert.NoError(t, err) {
 		return nil, err
 	}
+
+	// This is a hacky workaround. Read more in [SLOResource.updateEmptyAlertPolicies].
+	if object.GetKind() == manifest.KindSLO && len(objects) == 1 {
+		appliedAP := object.(v1alphaSLO.SLO).Spec.AlertPolicies
+		returnedAP := objects[0].(v1alphaSLO.SLO).Spec.AlertPolicies
+		if appliedAP != nil && len(appliedAP) == 0 && len(returnedAP) == 0 {
+			slo := objects[0].(v1alphaSLO.SLO)
+			slo.Spec.AlertPolicies = []string{}
+			objects[0] = slo
+		}
+	}
 	return objects, nil
 }
 

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -51,9 +51,6 @@ var sloResourceSchema = func() schema.Schema {
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: "Alert Policies attached to SLO.",
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-				},
 			},
 			"retrieve_historical_data_from": schema.StringAttribute{
 				Optional: true,

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -235,6 +235,151 @@ func TestAccSLOResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_changeAlertPolicies(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	manifestService := getExampleServiceResource(t).ToManifest()
+	manifestService.Metadata.Project = manifestProject.GetName()
+	auxiliaryObjects := []manifest.Object{manifestProject, manifestService}
+
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	manifestAlertPolicy := e2etestutils.GetExampleObject[v1alphaAlertPolicy.AlertPolicy](
+		t,
+		manifest.KindAlertPolicy,
+		nil,
+	)
+	manifestAlertPolicy.Metadata.Name = e2etestutils.GenerateName()
+	manifestAlertPolicy.Metadata.Project = manifestProject.GetName()
+	manifestAlertPolicy.Metadata.Labels = e2etestutils.AnnotateLabels(t, nil)
+	manifestAlertPolicy.Spec.AlertMethods = nil
+	auxiliaryObjects = append(auxiliaryObjects, manifestAlertPolicy)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = manifestProject.GetName()
+	sloResource.Service = manifestService.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+
+	sloResource.AlertPolicies = []string{manifestAlertPolicy.GetName()}
+
+	manifestSLO := sloResource.ToManifest()
+
+	sloConfig := newSLOResource(t, sloResource)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// 1. Create and Read.
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, auxiliaryObjects)
+					t.Cleanup(func() { e2etestutils.V1Delete(t, auxiliaryObjects) })
+				},
+				Config: sloConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, ctx, manifestSLO),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			// 2. Update project with alert policies - error.
+			{
+				Config: newSLOResource(t, func() sloResourceTemplateModel {
+					m := sloResource
+					m.Project = "new-project"
+					return m
+				}()),
+				ExpectError: regexp.MustCompile(`Cannot move SLO between Projects with attached Alert Policies.`),
+			},
+			// 3. Set alert policies to empty list
+			{
+				Config: newSLOResource(t, func() sloResourceTemplateModel {
+					m := sloResource
+					m.AlertPolicies = []string{}
+					return m
+				}()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "alert_policies.#", "0"),
+					assertResourceWasApplied(t, ctx, func() v1alphaSLO.SLO {
+						slo := manifestSLO
+						slo.Spec.AlertPolicies = []string{}
+						return slo
+					}()),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						expectChangesInResourcePlan(planDiff{Modified: []string{"alert_policies"}}),
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// 4. Remove Alert Policy from SLO.
+			{
+				Config: newSLOResource(t, func() sloResourceTemplateModel {
+					m := sloResource
+					m.AlertPolicies = nil
+					return m
+				}()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "alert_policies.#", "0"),
+					assertResourceWasApplied(t, ctx, func() v1alphaSLO.SLO {
+						slo := manifestSLO
+						slo.Spec.AlertPolicies = nil
+						return slo
+					}()),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						expectChangesInResourcePlan(planDiff{Modified: []string{"alert_policies"}}),
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// 5. Set alert policies to empty list again
+			{
+				Config: newSLOResource(t, func() sloResourceTemplateModel {
+					m := sloResource
+					m.AlertPolicies = []string{}
+					return m
+				}()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "alert_policies.#", "0"),
+					assertResourceWasApplied(t, ctx, func() v1alphaSLO.SLO {
+						slo := manifestSLO
+						slo.Spec.AlertPolicies = []string{}
+						return slo
+					}()),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						expectChangesInResourcePlan(planDiff{Modified: []string{"alert_policies"}}),
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccSLOResource_moveSLO(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -833,7 +833,6 @@ func TestAccSLOResource_custom(t *testing.T) {
 				model.AlertPolicies = []string{}
 				return model
 			},
-			expectedError: "Attribute alert_policies set must contain at least 1 elements, got: 0",
 		},
 		"with alert policies": {
 			sloResourceModelModifier: func(t *testing.T, model SLOResourceModel) SLOResourceModel {
@@ -1067,7 +1066,6 @@ func TestAccSLOResource_custom(t *testing.T) {
 				})
 				return
 			}
-
 			resource.Test(t, resource.TestCase{
 				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 				Steps: []resource.TestStep{


### PR DESCRIPTION
## Motivation

After the latest release it was not possible to set an empty list of alert policies in the SLO.
```
Error: Invalid Attribute Value

  with module.alerting.nobl9_slo.slo_c2ab7e2e_15c3_4523_b831_517563d77a3e,
  on ../services/alerting/main.tf line 2410, in resource "nobl9_slo" "slo_c2ab7e2e_15c3_4523_b831_517563d77a3e":
2410:   alert_policies   = []

Attribute alert_policies set must contain at least 1 elements, got: 0
```

## Summary

- Removed the minElements = 1 validation
- Hacked SLOResource to compensate for case when nobl9 API does not return an empty list (because of omit empty)

## Testing

- create SLO with empty alert policy
- create SLO with no alert policy
- create SLO with some alert policy
- detect drift if alert policies were changed from empty to filled
- detect drift if alert policies were changed from filled to empty
- update SLO from empty to filled alert policies
- update SLO from filled alert policies to empty

## Release Notes

Fix regression that did not allow setting empty `alert_policies` in the SLO
