### PR TITLE
chore: improve error messaging and fix alert policies handling

### DIFF
--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -114,7 +114,16 @@ func (s sdkClient) DryRunApplyObject(ctx context.Context, obj manifest.Object) d
 		return diag.Diagnostics{
 			diag.NewWarningDiagnostic(
 				fmt.Sprintf("Dry-run apply failed for %s %s", obj.GetVersion(), obj.GetKind()),
-				err.Error(),
+				fmt.Sprintf(
+					"Error: %s\n\n"+
+						"WARNING!\n\n"+
+						"Terraform Providers handle each resource in isolation.\n"+
+						"This means we cannot verify If your entire configuration is valid, "+
+						"the limitation includes name conflicts and non-existing object references.\n"+
+						"The error above might be a false positive and is thus displayed as a warning.\n "+
+						"This can happen for instance when you apply, for the first time, "+
+						"AlertPolicy and SLO which references the policy.",
+					err.Error()),
 			),
 		}
 	}

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -262,12 +262,12 @@ func (s *SLOResource) updateEmptyAlertPolicies(
 	model *SLOResourceModel,
 	slo v1alphaSLO.SLO,
 ) {
-	var alertPolicies *[]string
+	var alertPolicies []string
 	if !state.Raw.IsNull() && plan == nil {
 		// It's a Read - we need to take a look into the saved state
 		alertPoliciesPath := path.Root("alert_policies")
 		diagnostics.Append(state.GetAttribute(ctx, alertPoliciesPath, &alertPolicies)...)
-	} else if plan != nil { // nolint:gocritic
+	} else if plan != nil {
 		// Is' an Update, Create or Import - we need to read the plan
 		alertPoliciesPath := path.Root("alert_policies")
 		diagnostics.Append(plan.GetAttribute(ctx, alertPoliciesPath, &alertPolicies)...)
@@ -276,7 +276,7 @@ func (s *SLOResource) updateEmptyAlertPolicies(
 		return
 	}
 
-	alertPoliciesAreEmpty := alertPolicies != nil && len(*alertPolicies) == 0
+	alertPoliciesAreEmpty := alertPolicies != nil && len(alertPolicies) == 0
 	if alertPoliciesAreEmpty && len(slo.Spec.AlertPolicies) == 0 {
 		model.AlertPolicies = []string{}
 	}


### PR DESCRIPTION
## Motivation

Limitations imposed by Terraform architecture (resources are independent entities) mean we cannot fully verify if a configuration is valid. For instance, an SLO might reference a Service which is part of Terraform configuration. If both objects are not yet applied, the dry run validation will report that the Service does not exist.
In order to help users understand such errors, I want to add additional context explaining the situation we're in.

## Summary

Enhanced the error message in `DryRunApplyObject` to provide detailed context about potential false positives during dry-run apply operations. This includes warnings about Terraform Providers' limitations in verifying entire configurations, such as name conflicts and non-existing object references.

Refactored `updateEmptyAlertPolicies` in `SLOResource` to fix the handling of alert policies. Changed the type of `alertPolicies` from a pointer to a slice, ensuring proper checks for empty alert policies and aligning with the expected behavior. Removed unnecessary `nolint` directive for cleaner code.