### PR TITLE
chore: bump nobl9-go to v0.130.0-rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/nobl9/nobl9-go v0.129.1
+	github.com/nobl9/nobl9-go v0.130.0-rc2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/nobl9/nobl9-go v0.130.0-rc2
+	github.com/nobl9/nobl9-go v0.130.0-rc3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/nobl9/govy v0.26.0 h1:pjHXreO+3Rl+Uz6/rFX7L54zH4LW/SaTjb6YX3GQGs4=
 github.com/nobl9/govy v0.26.0/go.mod h1:fExiIzXORe0ktwg2bWasOAmCZtEFMQkR4PpgzhHcZSA=
-github.com/nobl9/nobl9-go v0.130.0-rc2 h1:q6B3PbIO/aMbL8SBd6fGEAKdr/P/uCd7vpP9H9Pyzfg=
-github.com/nobl9/nobl9-go v0.130.0-rc2/go.mod h1:UoFmEtBEI7tQL2Fnh+vXKtG5o0XMs3YJL41SlRxfuSY=
+github.com/nobl9/nobl9-go v0.130.0-rc3 h1:WmrKF2cb+cdosxo4nbF9PUD+nEABNHryV4P4DMDmDbI=
+github.com/nobl9/nobl9-go v0.130.0-rc3/go.mod h1:UoFmEtBEI7tQL2Fnh+vXKtG5o0XMs3YJL41SlRxfuSY=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/nobl9/govy v0.26.0 h1:pjHXreO+3Rl+Uz6/rFX7L54zH4LW/SaTjb6YX3GQGs4=
 github.com/nobl9/govy v0.26.0/go.mod h1:fExiIzXORe0ktwg2bWasOAmCZtEFMQkR4PpgzhHcZSA=
-github.com/nobl9/nobl9-go v0.129.1 h1:qJSbFwEuKBwOM+fALWQDOuUkWuLuCGA41w+vg6MXxVY=
-github.com/nobl9/nobl9-go v0.129.1/go.mod h1:UoFmEtBEI7tQL2Fnh+vXKtG5o0XMs3YJL41SlRxfuSY=
+github.com/nobl9/nobl9-go v0.130.0-rc2 h1:q6B3PbIO/aMbL8SBd6fGEAKdr/P/uCd7vpP9H9Pyzfg=
+github.com/nobl9/nobl9-go v0.130.0-rc2/go.mod h1:UoFmEtBEI7tQL2Fnh+vXKtG5o0XMs3YJL41SlRxfuSY=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
Picks up nobl9-go v0.130.0-rc3 which includes nobl9-go #929 "feat: split Splunk Observability agent example into stable + replay subvariant" - unblocks `TestAccSLOResource_examples/splunk_observability` that was failing with `can't switch between release channels` after the previous single example was flipped to beta.

## Related PRs

- nobl9-go #929 "feat: split Splunk Observability agent example into stable + replay subvariant" - the actual fix bundled into v0.130.0-rc3