### PR TITLE
chore: support fork PR autolabeling and Go 1.26.4

### DIFF
--- a/.github/workflows/pr-autolabeler.yml
+++ b/.github/workflows/pr-autolabeler.yml
@@ -1,0 +1,19 @@
+name: PR Autolabeler
+
+on:
+  # pull_request_target is required to label PRs from forks.
+  # This workflow must stay metadata-only: do not checkout or run PR code here.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,28 +4,11 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  # 'edited' event is required to account for initial invalid PR names
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
-
 permissions:
   contents: read
 
 jobs:
-  autolabeler:
-    if: github.event_name == 'pull_request'
-    permissions:
-      # write permission is required to add labels to pull requests
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter/autolabeler@v7
-        with:
-          token: ${{ secrets.RELEASE_LABELER_TOKEN }}
-
   update_release_draft:
-    if: github.event_name == 'push'
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/terraform-provider-nobl9
 
-go 1.25.10
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
@@ -83,9 +83,9 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/nobl9/govy v0.26.0 h1:pjHXreO+3Rl+Uz6/rFX7L54zH4LW/SaTjb6YX3GQGs4=
 github.com/nobl9/govy v0.26.0/go.mod h1:fExiIzXORe0ktwg2bWasOAmCZtEFMQkR4PpgzhHcZSA=
-github.com/nobl9/nobl9-go v0.130.0-rc1 h1:elzVPhOoaLEZDLn3fTyiGX544ImCs0Cjq9u0SBmr51E=
-github.com/nobl9/nobl9-go v0.130.0-rc1/go.mod h1:UoFmEtBEI7tQL2Fnh+vXKtG5o0XMs3YJL41SlRxfuSY=
 github.com/nobl9/nobl9-go v0.130.0-rc4 h1:kw6CuYrlAjbn1h/C3CIjt9lENDyyrm6CuZ4shWU8Des=
 github.com/nobl9/nobl9-go v0.130.0-rc4/go.mod h1:UoFmEtBEI7tQL2Fnh+vXKtG5o0XMs3YJL41SlRxfuSY=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
@@ -259,8 +257,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -278,8 +276,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=


### PR DESCRIPTION
## Motivation

External contributor PRs cannot access repository secrets even after a maintainer approves workflow execution. The previous Release Drafter autolabeler job required a secret token on `pull_request`, so fork PRs failed before labels could be applied.

## Summary

- Moves PR autolabeling to a separate metadata-only `pull_request_target` workflow.
- Uses `github.token` with `pull-requests: write` instead of repository secrets for PR labeling.
- Keeps Release Drafter itself on the trusted `push` path.
- Bumps Go to 1.26.4 so `govulncheck` uses the fixed standard library.
- Bumps `golang.org/x/net` to v0.55.0 for GO-2026-5026.

## Related Changes

https://github.com/nobl9/nobl9-go/pull/937
