### PR TITLE
fix: reject duplicate label keys [PC-19826]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@ List related changes from other PRs (if any).
 ## Testing
 
 - Describe how to check introduced code changes manually.
-- Take care of test coverage on unit, integration or end-to-end levels.
+- Simple `main.tf` which covers the changes is a welcome addition.
+- Take care of test coverage on unit and acceptance test levels.
 
 ## Release Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Do not use this file as a replacement for the project documentation.
 
 Read the existing docs before changing behavior, tests, or release logic:
 
-- [docs/DEVELOPMENT.md](./dev-docs/DEVELOPMENT.md) for development workflow,
+- [dev-docs/DEVELOPMENT.md](./dev-docs/DEVELOPMENT.md) for development workflow,
   Makefile behavior, CI, validation tests, e2e tests, code generation, and
   dependencies.
 - [README.md](./README.md) for user-facing purpose and usage.
@@ -40,7 +40,7 @@ Do not run them without explicit user permission.
 
 Before writing or modifying acceptance tests, read:
 
-- [docs/DEVELOPMENT.md](./docs/DEVELOPMENT.md#end-to-end-test)
+- [dev-docs/DEVELOPMENT.md](./dev-docs/DEVELOPMENT.md#end-to-end-test)
 - sample existing tests to follow the established style and practices
 
 ## Code standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Do not run them without explicit user permission.
 
 Before writing or modifying acceptance tests, read:
 
-- [dev-docs/DEVELOPMENT.md](./dev-docs/DEVELOPMENT.md#end-to-end-test)
+- [dev-docs/DEVELOPMENT.md](./dev-docs/DEVELOPMENT.md#testing)
 - sample existing tests to follow the established style and practices
 
 ## Code standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+This repository contains Terraform provider implementation for Nobl9 platform resources.
+Do not use this file as a replacement for the project documentation.
+
+Read the existing docs before changing behavior, tests, or release logic:
+
+- [docs/DEVELOPMENT.md](./dev-docs/DEVELOPMENT.md) for development workflow,
+  Makefile behavior, CI, validation tests, e2e tests, code generation, and
+  dependencies.
+- [README.md](./README.md) for user-facing purpose and usage.
+- [dev-docs/RELEASE.md](./dev-docs/RELEASE.md) for release automation details.
+- [dev-docs/plugin-framework-migration.md](./dev-docs/plugin-framework-migration.md)
+  for instructions when migrating [legacy SDK resources](./nobl9/)
+  to the [new framework library](./internal/frameworkprovider/).
+
+If a workflow is documented there, follow the existing doc instead of adding
+a second version here.
+
+## Migration status
+
+This repository is in the middle of migration between the legacy SDK,
+located under `./nobl9` and the new provider framework located under
+`./internal/frameworkprovider`.
+Depending on which one you're working under, adhere to the respective standards.
+Read more about it in [./dev-docs/plugin-framework-migration.md](./dev-docs/plugin-framework-migration.md).
+
+## Testing
+
+Write end-to-end acceptance tests over unit tests by default.
+
+Unit tests are acceptable for narrow internal logic, edge cases,
+or failure branches that cannot be exercised through acceptance tests without brittle
+setup or excessive external state.
+If you choose unit-only coverage for a behavior change, state the reason in
+the PR or handoff notes.
+
+Acceptance tests talk to the Nobl9 platform API.
+Do not run them without explicit user permission.
+
+Before writing or modifying acceptance tests, read:
+
+- [docs/DEVELOPMENT.md](./docs/DEVELOPMENT.md#end-to-end-test)
+- sample existing tests to follow the established style and practices
+
+## Code standards
+
+Follow existing package layout, command patterns, and test style before adding
+new abstractions.
+
+Do not edit generated files directly.
+If generated output is stale, update the source definitions and run
+`make generate`, then verify with `make check/generate`.
+
+### Shell
+
+Use the Makefile targets instead of calling tools directly.
+To inspect available targets, run: `make help`.
+The CI workflows under [.github/workflows](./.github/workflows/) use the same
+Makefile targets, so treat them as the local source of verification commands.
+
+## Pull requests
+
+When creating or updating a pull request description,
+follow guidelines and template defined in
+[.github/pull_request_template.md](./.github/pull_request_template.md).
+Do not introduce new sections, subsections for the existing ones are acceptable.
+Fill only the sections that apply, remove template instructions from the final
+description, and remove the `## Release Notes` section entirely when the change
+does not need release notes.
+Always ask the use for for `## Motivation`,
+unless you already know it from a spec or ticket.
+Be vigilant of any breaking changes and document them in `## Breaking Changes` section.
+
+## Verification
+
+Always verify changes with project targets before claiming completion.
+For Markdown-only changes, run `make check/markdown` at minimum.
+
+If a command cannot be run locally, report the exact command and exact error.
+Do not replace failed verification with assumptions.

--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -219,7 +219,7 @@ and you can place them in the templates using the following functions:
       // When set to false, you won't need to provide any further env variables.
       no_config_file = false
     }
-    
+
     resource "nobl9_project" "this" {
       name         = "my-project"
     }

--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -47,15 +47,21 @@ More on acceptance tests can be found
 The acceptance tests are only run automatically for releases, be it official
 version or pre-release (release candidate).
 The tests are executed against the production application.
-If you want to run the tests manually against a different environment, you can
-run the following command:
+If you already have a Nobl9 `config.toml` on your machine with valid device credentials,
+run this command:
+
+```shell
+NOBL9_NO_CONFIG_FILE=false \
+make test/acc
+```
+
+Otherwise, you need to provide all the required auth details like this:
 
 ```shell
 NOBL9_CLIENT_ID=<client_id> \
 NOBL9_CLIENT_SECRET=<client_secret> \
 NOBL9_OKTA_URL=https://accounts.nobl9.dev \
 NOBL9_OKTA_AUTH=<dev_auth_server> \
-NOBL9_URL=<ingest_server_url> \
 make test/acc
 ```
 
@@ -206,6 +212,16 @@ and you can place them in the templates using the following functions:
           version = "0.19.0"
         }
       }
+    }
+
+    provider "nobl9" {
+      // Add this If you want to use `config.toml` credentials.
+      // When set to false, you won't need to provide any further env variables.
+      no_config_file = false
+    }
+    
+    resource "nobl9_project" "this" {
+      name         = "my-project"
     }
     ```
 

--- a/internal/frameworkprovider/metadata_labels_block.go
+++ b/internal/frameworkprovider/metadata_labels_block.go
@@ -57,6 +57,9 @@ func (l Labels) ToManifest() v1alpha.Labels {
 func metadataLabelsBlock() *schema.ListNestedBlock {
 	return &schema.ListNestedBlock{
 		Description: "[Labels](https://docs.nobl9.com/features/labels/) containing a single key and a list of values.",
+		Validators: []validator.List{
+			labelKeysUniqueValidator{},
+		},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"key": schema.StringAttribute{

--- a/internal/frameworkprovider/provider.go
+++ b/internal/frameworkprovider/provider.go
@@ -89,10 +89,6 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(model.validate()...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	client, diags := newSDKClient(model)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/internal/frameworkprovider/provider_model.go
+++ b/internal/frameworkprovider/provider_model.go
@@ -2,7 +2,6 @@ package frameworkprovider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -54,25 +53,4 @@ func (p *ProviderModel) setDefaultsFromEnv() diag.Diagnostics {
 		p.NoConfigFile = env.NoConfigFile
 	}
 	return nil
-}
-
-// validate ensures required fields are set.
-// It should be called after [ProviderModel.setDefaultsFromEnv] is called.
-func (p *ProviderModel) validate() diag.Diagnostics {
-	diags := diag.Diagnostics{}
-	if p.ClientID.IsNull() {
-		diags.Append(diag.NewAttributeErrorDiagnostic(
-			path.Root("client_id"),
-			"missing required field",
-			"client_id is required to connect to Nobl9",
-		))
-	}
-	if p.ClientSecret.IsNull() {
-		diags.Append(diag.NewAttributeErrorDiagnostic(
-			path.Root("client_secret"),
-			"missing required field",
-			"client_secret is required to connect to Nobl9",
-		))
-	}
-	return diags
 }

--- a/internal/frameworkprovider/provider_test.go
+++ b/internal/frameworkprovider/provider_test.go
@@ -78,6 +78,7 @@ var (
 	}
 	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"nobl9": func() (tfprotov6.ProviderServer, error) {
+			defaultToConfigFileForAcceptanceTests()
 			testAccProviderServer.once.Do(func() {
 				testAccProviderServer.srv, testAccProviderServer.err = testAccNewMux(context.Background())
 			})
@@ -96,15 +97,7 @@ var testSDKClient = struct {
 func testAccSetup(t *testing.T) {
 	t.Helper()
 	checkIfAcceptanceTestIsSet(t)
-
-	// Check ENVs everytime to fail all tests using the SDK client
-	for _, key := range []string{
-		"NOBL9_CLIENT_ID",
-		"NOBL9_CLIENT_SECRET",
-	} {
-		_, ok := os.LookupEnv(key)
-		require.True(t, ok, "required environment variable %q is not set", key)
-	}
+	defaultToConfigFileForAcceptanceTests()
 
 	// Initialize the SDK client.
 	testSDKClient.once.Do(func() {
@@ -128,6 +121,12 @@ func testAccSetup(t *testing.T) {
 			testSDKClient.client.Config.OktaOrgURL.JoinPath(testSDKClient.client.Config.OktaAuthServer),
 			testSDKClient.client.Config.ClientID)
 	})
+}
+
+func defaultToConfigFileForAcceptanceTests() {
+	if _, ok := os.LookupEnv("NOBL9_NO_CONFIG_FILE"); !ok {
+		_ = os.Setenv("NOBL9_NO_CONFIG_FILE", "false")
+	}
 }
 
 // assertResourceWasApplied is a test check function that asserts if the resource was applied

--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -31,7 +31,6 @@ type sdkClient struct {
 }
 
 // newSDKClient creates new [sdk.Client] based on the [ProviderModel].
-// [ProviderModel] should be first validated with [ProviderModel] before being passed to this function.
 func newSDKClient(provider ProviderModel) (*sdkClient, diag.Diagnostics) {
 	options := []sdk.ConfigOption{
 		sdk.ConfigOptionWithCredentials(provider.ClientID.ValueString(), provider.ClientSecret.ValueString()),
@@ -43,6 +42,9 @@ func newSDKClient(provider ProviderModel) (*sdkClient, diag.Diagnostics) {
 	sdkConfig, err := sdk.ReadConfig(options...)
 	if err != nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("failed to read Nobl9 SDK configuration", err.Error())}
+	}
+	if diags := validateResolvedCredentials(sdkConfig); diags.HasError() {
+		return nil, diags
 	}
 	if ingestURL := provider.IngestURL.ValueString(); ingestURL != "" {
 		sdkConfig.URL, err = url.Parse(ingestURL)
@@ -79,6 +81,36 @@ func newSDKClient(provider ProviderModel) (*sdkClient, diag.Diagnostics) {
 	}
 	setClientUserAgent(client)
 	return &sdkClient{client: client}, nil
+}
+
+func validateResolvedCredentials(config *sdk.Config) diag.Diagnostics {
+	if config.AccessToken != "" || config.DisableOkta {
+		return nil
+	}
+	if config.ClientID == "" && config.ClientSecret == "" {
+		return diag.Diagnostics{diag.NewErrorDiagnostic(
+			"missing Nobl9 client credentials",
+			"Both client_id and client_secret must be provided through provider configuration, "+
+				"environment variables, or Nobl9 configuration file.",
+		)}
+	}
+	if config.ClientID == "" {
+		return diag.Diagnostics{diag.NewAttributeErrorDiagnostic(
+			path.Root("client_id"),
+			"missing Nobl9 client ID",
+			"client_id must be provided together with client_secret through provider configuration, "+
+				"environment variables, or Nobl9 configuration file.",
+		)}
+	}
+	if config.ClientSecret == "" {
+		return diag.Diagnostics{diag.NewAttributeErrorDiagnostic(
+			path.Root("client_secret"),
+			"missing Nobl9 client secret",
+			"client_secret must be provided together with client_id through provider configuration, "+
+				"environment variables, or Nobl9 configuration file.",
+		)}
+	}
+	return nil
 }
 
 func (s sdkClient) ApplyObject(ctx context.Context, obj manifest.Object) diag.Diagnostics {

--- a/internal/frameworkprovider/sdk_client_test.go
+++ b/internal/frameworkprovider/sdk_client_test.go
@@ -1,0 +1,60 @@
+package frameworkprovider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSDKClientUsesConfigFileCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`defaultContext = "default"
+
+[Contexts]
+  [Contexts.default]
+    clientId = "config-client-id"
+    clientSecret = "config-client-secret"
+`), 0o600))
+
+	t.Setenv("TERRAFORM_NOBL9_CONFIG_FILE_PATH", configPath)
+	t.Setenv("TERRAFORM_NOBL9_NO_CONFIG_FILE", "false")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_ID", "")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_SECRET", "")
+
+	client, diags := newSDKClient(ProviderModel{
+		NoConfigFile: envConfigurableBool{BoolValue: basetypes.NewBoolValue(false)},
+	})
+
+	require.False(t, diags.HasError(), diags.Errors())
+	require.NotNil(t, client)
+	assert.Equal(t, "config-client-id", client.client.Config.ClientID)
+	assert.Equal(t, "config-client-secret", client.client.Config.ClientSecret)
+}
+
+func TestNewSDKClientRejectsPartialConfigFileCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`defaultContext = "default"
+
+[Contexts]
+  [Contexts.default]
+    clientId = "config-client-id"
+`), 0o600))
+
+	t.Setenv("TERRAFORM_NOBL9_CONFIG_FILE_PATH", configPath)
+	t.Setenv("TERRAFORM_NOBL9_NO_CONFIG_FILE", "false")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_ID", "")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_SECRET", "")
+	t.Setenv("TERRAFORM_NOBL9_ACCESS_TOKEN", "")
+
+	client, diags := newSDKClient(ProviderModel{
+		NoConfigFile: envConfigurableBool{BoolValue: basetypes.NewBoolValue(false)},
+	})
+
+	require.True(t, diags.HasError())
+	require.Nil(t, client)
+	assert.Equal(t, "missing Nobl9 client secret", diags[0].Summary())
+}

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -235,6 +235,33 @@ func TestAccSLOResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_labelValidationErrors(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	model := getExampleSLOResource(t)
+	model.Labels = Labels{
+		{Key: "slo-owners", Values: []string{"team-a"}},
+		{Key: "slo-owners", Values: []string{"team-b"}},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: newSLOResource(t, sloResourceTemplateModel{
+					ResourceName:     "test",
+					SLOResourceModel: model,
+				}),
+				ExpectError: regexp.MustCompile(
+					`duplicate label key \[slo-owners\] found - expected only one occurrence of each label key`,
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccSLOResource_changeAlertPolicies(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -254,7 +254,7 @@ func TestAccSLOResource_labelValidationErrors(t *testing.T) {
 					SLOResourceModel: model,
 				}),
 				ExpectError: regexp.MustCompile(
-					`duplicate label key \[slo-owners\] found - expected only one occurrence of each label key`,
+					`duplicate label key \[slo-owners\] found - expected only one occurrence of each\s+label key`,
 				),
 				PlanOnly: true,
 			},

--- a/internal/frameworkprovider/validators.go
+++ b/internal/frameworkprovider/validators.go
@@ -153,3 +153,51 @@ func (v sumoLogicQueriesUniqueRowIDValidator) ValidateList(
 		seen[id] = true
 	}
 }
+
+type labelKeysUniqueValidator struct{}
+
+func (v labelKeysUniqueValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v labelKeysUniqueValidator) MarkdownDescription(_ context.Context) string {
+	return "Ensure that label keys are unique"
+}
+
+func (v labelKeysUniqueValidator) ValidateList(
+	_ context.Context,
+	req validator.ListRequest,
+	resp *validator.ListResponse,
+) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || len(req.ConfigValue.Elements()) == 0 {
+		return
+	}
+	seenKeys := make(map[string]struct{}, len(req.ConfigValue.Elements()))
+	for i, elem := range req.ConfigValue.Elements() {
+		obj, ok := elem.(types.Object)
+		if !ok || obj.IsNull() || obj.IsUnknown() {
+			continue
+		}
+		keyAttr, exists := obj.Attributes()["key"]
+		if !exists {
+			continue
+		}
+		key, ok := keyAttr.(types.String)
+		if !ok || key.IsNull() || key.IsUnknown() {
+			continue
+		}
+		keyValue := key.ValueString()
+		if _, ok := seenKeys[keyValue]; ok {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtListIndex(i).AtName("key"),
+				"duplicate label key",
+				fmt.Sprintf(
+					"duplicate label key [%s] found - expected only one occurrence of each label key",
+					keyValue,
+				),
+			)
+			return
+		}
+		seenKeys[keyValue] = struct{}{}
+	}
+}

--- a/nobl9/provider_test.go
+++ b/nobl9/provider_test.go
@@ -66,6 +66,7 @@ var (
 	}
 	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"nobl9": func() (tfprotov6.ProviderServer, error) {
+			defaultToConfigFileForAcceptanceTests()
 			testAccProviderServer.once.Do(func() {
 				testAccProviderServer.srv, testAccProviderServer.err = testAccNewMux(context.Background())
 			})
@@ -73,6 +74,12 @@ var (
 		},
 	}
 )
+
+func defaultToConfigFileForAcceptanceTests() {
+	if _, ok := os.LookupEnv("NOBL9_NO_CONFIG_FILE"); !ok {
+		_ = os.Setenv("NOBL9_NO_CONFIG_FILE", "false")
+	}
+}
 
 func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {


### PR DESCRIPTION
## Motivation

Terraform configurations could define multiple `label` blocks with the same key.
That should be rejected with a clear Terraform validation error instead of letting duplicate keys collapse into a manifest map.

## Summary

Added shared label key uniqueness validation for metadata label blocks.
Added an SLO acceptance-plan validation case that expects a duplicate label key error.

### Config loading changes

Moved provider credential validation to run after Nobl9 SDK configuration is resolved.
This lets provider configuration use credentials loaded from the Nobl9 `config.toml` when config-file loading is enabled,
instead of requiring `client_id` and `client_secret` to be present directly in Terraform configuration or `NOBL9_` environment variables.

The provider contract did not change:
`no_config_file` still defaults to `true`,
so users must opt into config-file loading with `no_config_file = false` or `NOBL9_NO_CONFIG_FILE=false`.
The validation now checks the final resolved SDK configuration,
which keeps missing and partial credential errors while allowing the SDK-supported config-file source to satisfy them.

## Testing

Covered duplicate SLO label blocks with an acceptance-style plan validation test.

Minimal project-resource configuration to verify the same validation manually:

```hcl
terraform {
  required_providers {
    nobl9 = {
      source = "nobl9/nobl9"
    }
  }
}

provider "nobl9" {}

resource "nobl9_project" "duplicate_label_key" {
  name         = "pc-19826-duplicate-label-key"
  display_name = "PC-19826 Duplicate Label Key"

  label {
    key    = "team"
    values = ["alpha"]
  }

  label {
    key    = "team"
    values = ["beta"]
  }
}
```

Running `terraform plan` with this configuration should fail during validation with:

<img width="796" height="223" alt="image" src="https://github.com/user-attachments/assets/dabd02a6-1f9f-4198-8c4d-4d80a2bb9a55" />

## Release Notes

Duplicate label keys in Terraform resource `label` blocks were rejected with a validation error.
