### PR TITLE
chore: bump SDK for Splunk Observability examples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/nobl9/nobl9-go v0.131.0
+	github.com/nobl9/nobl9-go v0.133.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nobl9/govy v0.26.0 h1:pjHXreO+3Rl+Uz6/rFX7L54zH4LW/SaTjb6YX3GQGs4=
 github.com/nobl9/govy v0.26.0/go.mod h1:fExiIzXORe0ktwg2bWasOAmCZtEFMQkR4PpgzhHcZSA=
-github.com/nobl9/nobl9-go v0.131.0 h1:NRIbnHScO43OwYyFNa89UdidMHbZaTXBW7HOQ3pH6nw=
-github.com/nobl9/nobl9-go v0.131.0/go.mod h1:XUE+S6kcSkelfyXIuXxi6ep50LefQqVUUsn/Sqb5/2s=
+github.com/nobl9/nobl9-go v0.133.0 h1:UNLmpAoVgAkVnSfm6pIevVL65i74MM50Mu+IMEdeQEI=
+github.com/nobl9/nobl9-go v0.133.0/go.mod h1:XUE+S6kcSkelfyXIuXxi6ep50LefQqVUUsn/Sqb5/2s=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
## Release Notes


## Motivation

Terraform Provider acceptance tests use Nobl9 SDK example fixtures to provision shared SLO data sources. The previous SDK dependency emitted a stable Splunk Observability Agent, which the current Nobl9 API rejects; bumping the SDK dependency picks up the beta fixture.

## Summary

Update `github.com/nobl9/nobl9-go` from `v0.131.0` to `v0.133.0`.

## Related Changes

- Nobl9 SDK release: https://github.com/nobl9/nobl9-go/releases/tag/v0.133.0
