### PR TITLE
fix: preserve omitted SLO indicator project

### DIFF
--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -253,11 +253,21 @@ func (s *SLOResource) readResource(
 		return nil, diagnostics
 	}
 	updatedModel := newSLOResourceConfigFromManifest(slo)
+	preserveNullIndicatorProject(model, updatedModel)
 	s.updateEmptyAlertPolicies(ctx, diagnostics, state, plan, updatedModel, slo)
 	s.updateEmptyCompositeAggregation(ctx, state, plan, updatedModel)
 	s.sortLists(model, updatedModel)
 
 	return updatedModel, diagnostics
+}
+
+func preserveNullIndicatorProject(source, target *SLOResourceModel) {
+	if len(source.Indicator) == 0 || len(target.Indicator) == 0 {
+		return
+	}
+	if source.Indicator[0].Project.IsNull() {
+		target.Indicator[0].Project = source.Indicator[0].Project
+	}
 }
 
 // updateEmptyCompositeAggregation handles the case when:

--- a/internal/frameworkprovider/slo_resource_state_test.go
+++ b/internal/frameworkprovider/slo_resource_state_test.go
@@ -1,0 +1,64 @@
+package frameworkprovider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_preserveNullIndicatorProject(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		source          *SLOResourceModel
+		target          *SLOResourceModel
+		expectedProject types.String
+	}{
+		"omitted project": {
+			source: &SLOResourceModel{
+				Indicator: []IndicatorModel{{
+					Project: types.StringNull(),
+				}},
+			},
+			target: &SLOResourceModel{
+				Indicator: []IndicatorModel{{
+					Project: types.StringValue("default"),
+				}},
+			},
+			expectedProject: types.StringNull(),
+		},
+		"explicit project": {
+			source: &SLOResourceModel{
+				Indicator: []IndicatorModel{{
+					Project: types.StringValue("metrics"),
+				}},
+			},
+			target: &SLOResourceModel{
+				Indicator: []IndicatorModel{{
+					Project: types.StringValue("metrics"),
+				}},
+			},
+			expectedProject: types.StringValue("metrics"),
+		},
+		"missing source indicator": {
+			source: &SLOResourceModel{},
+			target: &SLOResourceModel{
+				Indicator: []IndicatorModel{{
+					Project: types.StringValue("default"),
+				}},
+			},
+			expectedProject: types.StringValue("default"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			preserveNullIndicatorProject(test.source, test.target)
+
+			assert.Equal(t, test.expectedProject, test.target.Indicator[0].Project)
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Valid SLO configurations that omit the optional `indicator.project` fail during apply with `Provider produced inconsistent result after apply` because the API resolves the project while Terraform planned a null value.

## Summary

Preserved the planned or prior null indicator project during state reconciliation without changing explicit projects or import-hydrated state. Added focused regression coverage for the preserved state semantics.

## Testing

Try applying an SLO with the following indicator shape:

```hcl
  indicator {
    name = "prometheus"
  }
```

Prior to the fix, it would fail with:

```text
nobl9_slo.slo_1: Creating...
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to nobl9_slo.slo_1, provider "provider[\"registry.terraform.io/nobl9/nobl9\"]" produced an unexpected new value: .indicator[0].project: was null, but now cty.StringVal("default").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

After the fix, it is created with any problems.

## Release Notes

Fixed SLO creation when the optional `indicator.project` is omitted.
