### PR TITLE
fix: read config file by default

### DIFF
--- a/dev-docs/DEVELOPMENT.md
+++ b/dev-docs/DEVELOPMENT.md
@@ -51,7 +51,6 @@ If you already have a Nobl9 `config.toml` on your machine with valid device cred
 run this command:
 
 ```shell
-NOBL9_NO_CONFIG_FILE=false \
 make test/acc
 ```
 
@@ -214,19 +213,21 @@ and you can place them in the templates using the following functions:
       }
     }
 
-    provider "nobl9" {
-      // Add this If you want to use `config.toml` credentials.
-      // When set to false, you won't need to provide any further env variables.
-      no_config_file = false
-    }
+    provider "nobl9" {}
 
     resource "nobl9_project" "this" {
       name         = "my-project"
     }
     ```
 
-    Now you're all set, you can use the locally built provider anywhere, as long
-    as you use the right version (see above).
+    When provider credentials and `NOBL9_` environment variables
+    are absent or empty,
+    the provider reads credentials from `config.toml`.
+    Set `no_config_file = true` to disable this fallback.
+
+    Now you're all set.
+    You can use the locally built provider anywhere,
+    as long as you use the right version (see above).
 
 ## Releases
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,13 @@ The Nobl9 Terraform Provider does not support the configuration of the following
 
 ## Configuration
 
-To start using Nobl9 Terraform Provider, you must configure the provider with the proper credentials. Then, use the navigation on the left to learn more about the available resources.
+Configure the provider with credentials in the provider block,
+`NOBL9_` environment variables,
+or the Nobl9 `config.toml` file.
+Provider arguments take precedence over environment variables,
+which take precedence over `config.toml`.
+Configuration-file loading is enabled by default.
+Set `no_config_file = true` to disable it.
 
 The following is an exemplary configuration:
 
@@ -57,7 +63,7 @@ provider "nobl9" {
 - `client_id` (String) The [Client ID](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.
 - `client_secret` (String, Sensitive) The [Client Secret](https://docs.nobl9.com/sloctl-user-guide/#configuration) of your Nobl9 account required to connect to Nobl9.
 - `ingest_url` (String) Nobl9 API URL.
-- `no_config_file` (Boolean) Disable reading configuration from file.
+- `no_config_file` (Boolean) Set to true to disable reading configuration from file. Defaults to false.
 - `okta_auth_server` (String) Authorization service configuration.
 - `okta_org_url` (String) Authorization service URL.
 - `organization` (String) Nobl9 Organization ID that contains resources managed by the provider.

--- a/internal/frameworkprovider/provider.go
+++ b/internal/frameworkprovider/provider.go
@@ -71,7 +71,7 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 			},
 			"no_config_file": schema.BoolAttribute{
 				Optional:    true,
-				Description: "Disable reading configuration from file.",
+				Description: "Set to true to disable reading configuration from file. Defaults to false.",
 				CustomType:  envConfigurableBoolType{},
 			},
 		},

--- a/internal/frameworkprovider/provider_model.go
+++ b/internal/frameworkprovider/provider_model.go
@@ -14,7 +14,7 @@ type ProviderModel struct {
 	Project        envConfigurableString `tfsdk:"project"          envconfig:"PROJECT"`
 	IngestURL      envConfigurableString `tfsdk:"ingest_url"       envconfig:"URL"`
 	Organization   envConfigurableString `tfsdk:"organization"     envconfig:"ORG"`
-	NoConfigFile   envConfigurableBool   `tfsdk:"no_config_file"   envconfig:"NO_CONFIG_FILE" default:"true"`
+	NoConfigFile   envConfigurableBool   `tfsdk:"no_config_file"   envconfig:"NO_CONFIG_FILE" default:"false"`
 }
 
 // setDefaultsFromEnv sets the default values for the [ProviderModel] from the

--- a/internal/frameworkprovider/sdk_client_test.go
+++ b/internal/frameworkprovider/sdk_client_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewSDKClientUsesConfigFileCredentials(t *testing.T) {
+func TestNewSDKClientUsesConfigFileCredentialsByDefault(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`defaultContext = "default"
 
@@ -20,14 +20,17 @@ func TestNewSDKClientUsesConfigFileCredentials(t *testing.T) {
     clientSecret = "config-client-secret"
 `), 0o600))
 
-	t.Setenv("TERRAFORM_NOBL9_CONFIG_FILE_PATH", configPath)
-	t.Setenv("TERRAFORM_NOBL9_NO_CONFIG_FILE", "false")
-	t.Setenv("TERRAFORM_NOBL9_CLIENT_ID", "")
-	t.Setenv("TERRAFORM_NOBL9_CLIENT_SECRET", "")
+	setSDKConfigFileTestEnv(t, configPath)
+	unsetProviderConfigEnv(t)
 
-	client, diags := newSDKClient(ProviderModel{
-		NoConfigFile: envConfigurableBool{BoolValue: basetypes.NewBoolValue(false)},
-	})
+	provider := ProviderModel{
+		ClientID:     envConfigurableString{StringValue: basetypes.NewStringValue("")},
+		ClientSecret: envConfigurableString{StringValue: basetypes.NewStringValue("")},
+	}
+	defaultDiags := provider.setDefaultsFromEnv()
+	require.False(t, defaultDiags.HasError(), defaultDiags.Errors())
+
+	client, diags := newSDKClient(provider)
 
 	require.False(t, diags.HasError(), diags.Errors())
 	require.NotNil(t, client)
@@ -44,11 +47,7 @@ func TestNewSDKClientRejectsPartialConfigFileCredentials(t *testing.T) {
     clientId = "config-client-id"
 `), 0o600))
 
-	t.Setenv("TERRAFORM_NOBL9_CONFIG_FILE_PATH", configPath)
-	t.Setenv("TERRAFORM_NOBL9_NO_CONFIG_FILE", "false")
-	t.Setenv("TERRAFORM_NOBL9_CLIENT_ID", "")
-	t.Setenv("TERRAFORM_NOBL9_CLIENT_SECRET", "")
-	t.Setenv("TERRAFORM_NOBL9_ACCESS_TOKEN", "")
+	setSDKConfigFileTestEnv(t, configPath)
 
 	client, diags := newSDKClient(ProviderModel{
 		NoConfigFile: envConfigurableBool{BoolValue: basetypes.NewBoolValue(false)},
@@ -57,4 +56,56 @@ func TestNewSDKClientRejectsPartialConfigFileCredentials(t *testing.T) {
 	require.True(t, diags.HasError())
 	require.Nil(t, client)
 	assert.Equal(t, "missing Nobl9 client secret", diags[0].Summary())
+}
+
+func setSDKConfigFileTestEnv(t *testing.T, configPath string) {
+	t.Helper()
+
+	t.Setenv("TERRAFORM_NOBL9_CONFIG_FILE_PATH", configPath)
+	t.Setenv("TERRAFORM_NOBL9_NO_CONFIG_FILE", "false")
+	t.Setenv("TERRAFORM_NOBL9_DEFAULT_CONTEXT", "")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_ID", "")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_SECRET", "")
+	t.Setenv("TERRAFORM_NOBL9_ACCESS_TOKEN", "")
+	t.Setenv("TERRAFORM_NOBL9_DISABLE_OKTA", "false")
+	t.Setenv("TERRAFORM_NOBL9_FILES_PROMPT_ENABLED", "")
+	t.Setenv("TERRAFORM_NOBL9_FILES_PROMPT_THRESHOLD", "")
+	t.Setenv("TERRAFORM_NOBL9_PROJECT", "")
+	t.Setenv("TERRAFORM_NOBL9_URL", "")
+	t.Setenv("TERRAFORM_NOBL9_OKTA_ORG_URL", "")
+	t.Setenv("TERRAFORM_NOBL9_OKTA_AUTH_SERVER", "")
+	t.Setenv("TERRAFORM_NOBL9_ORGANIZATION", "")
+	t.Setenv("TERRAFORM_NOBL9_TIMEOUT", "")
+	t.Setenv("TERRAFORM_NOBL9_CA_CERT_FILE", "")
+}
+
+func unsetProviderConfigEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"NOBL9_CLIENT_ID",
+		"NOBL9_CLIENT_SECRET",
+		"NOBL9_OKTA_URL",
+		"NOBL9_OKTA_AUTH",
+		"NOBL9_PROJECT",
+		"NOBL9_URL",
+		"NOBL9_ORG",
+		"NOBL9_NO_CONFIG_FILE",
+	} {
+		unsetEnv(t, key)
+	}
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	value, exists := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if exists {
+			require.NoError(t, os.Setenv(key, value))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
 }

--- a/nobl9/provider.go
+++ b/nobl9/provider.go
@@ -72,8 +72,8 @@ func Provider() *schema.Provider {
 			"no_config_file": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NOBL9_NO_CONFIG_FILE", true),
-				Description: "Disable reading configuration from file.",
+				DefaultFunc: schema.EnvDefaultFunc("NOBL9_NO_CONFIG_FILE", false),
+				Description: "Set to true to disable reading configuration from file. Defaults to false.",
 			},
 		},
 

--- a/nobl9/provider_test.go
+++ b/nobl9/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -21,6 +22,8 @@ import (
 	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/sdk"
 	v1Objects "github.com/nobl9/nobl9-go/sdk/endpoints/objects/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/nobl9/terraform-provider-nobl9/internal/frameworkprovider"
 )
@@ -87,6 +90,87 @@ func TestProvider(t *testing.T) {
 	}
 }
 
+func TestProviderResolvesCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`defaultContext = "default"
+
+[Contexts]
+  [Contexts.default]
+    clientId = "config-client-id"
+    clientSecret = "config-value"
+`), 0o600))
+
+	var emptyValue string
+	configValue := "config-value"
+	envValue := "env-value"
+	providerValue := "provider-value"
+	tests := map[string]struct {
+		providerConfig       map[string]any
+		envClientID          string
+		envClientSecret      string
+		expectedClientID     string
+		expectedClientSecret string
+		expectedNoConfigFile bool
+	}{
+		"config file fallback for empty credentials": {
+			providerConfig: map[string]any{
+				"client_id":     "",
+				"client_secret": emptyValue,
+			},
+			expectedClientID:     "config-client-id",
+			expectedClientSecret: configValue,
+		},
+		"environment variables before config file": {
+			envClientID:          "env-client-id",
+			envClientSecret:      envValue,
+			expectedClientID:     "env-client-id",
+			expectedClientSecret: envValue,
+		},
+		"provider configuration before environment and config file": {
+			providerConfig: map[string]any{
+				"client_id":     "provider-client-id",
+				"client_secret": providerValue,
+			},
+			envClientID:          "env-client-id",
+			envClientSecret:      envValue,
+			expectedClientID:     "provider-client-id",
+			expectedClientSecret: providerValue,
+		},
+		"config file disabled": {
+			providerConfig: map[string]any{
+				"client_id":      "provider-client-id",
+				"client_secret":  providerValue,
+				"no_config_file": true,
+			},
+			expectedClientID:     "provider-client-id",
+			expectedClientSecret: providerValue,
+			expectedNoConfigFile: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetProviderClient(t)
+			setSDKConfigFileTestEnv(t, configPath)
+			unsetProviderConfigEnv(t)
+			if tt.envClientID != "" {
+				t.Setenv("NOBL9_CLIENT_ID", tt.envClientID)
+				t.Setenv("NOBL9_CLIENT_SECRET", tt.envClientSecret)
+			}
+
+			data := schema.TestResourceDataRaw(t, Provider().Schema, tt.providerConfig)
+			client, diags := getClient(getProviderConfig(data))
+
+			require.False(t, diags.HasError(), diags)
+			require.NotNil(t, client)
+			assert.Equal(t, tt.expectedClientID, client.Config.ClientID)
+			assert.Equal(t, tt.expectedClientSecret, client.Config.ClientSecret)
+			if tt.expectedNoConfigFile {
+				assert.Nil(t, client.Config.GetFileConfig())
+			}
+		})
+	}
+}
+
 func CheckObjectCreated(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -97,6 +181,75 @@ func CheckObjectCreated(name string) resource.TestCheckFunc {
 			return fmt.Errorf("ID not set")
 		}
 		return nil
+	}
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	value, exists := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset environment variable %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if exists {
+			if err := os.Setenv(key, value); err != nil {
+				t.Errorf("restore environment variable %s: %v", key, err)
+			}
+			return
+		}
+		if err := os.Unsetenv(key); err != nil {
+			t.Errorf("unset environment variable %s during cleanup: %v", key, err)
+		}
+	})
+}
+
+func resetProviderClient(t *testing.T) {
+	t.Helper()
+
+	sharedClient = nil
+	once = sync.Once{}
+	t.Cleanup(func() {
+		sharedClient = nil
+		once = sync.Once{}
+	})
+}
+
+func setSDKConfigFileTestEnv(t *testing.T, configPath string) {
+	t.Helper()
+
+	t.Setenv("TERRAFORM_NOBL9_CONFIG_FILE_PATH", configPath)
+	t.Setenv("TERRAFORM_NOBL9_NO_CONFIG_FILE", "false")
+	t.Setenv("TERRAFORM_NOBL9_DEFAULT_CONTEXT", "")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_ID", "")
+	t.Setenv("TERRAFORM_NOBL9_CLIENT_SECRET", "")
+	t.Setenv("TERRAFORM_NOBL9_ACCESS_TOKEN", "")
+	t.Setenv("TERRAFORM_NOBL9_DISABLE_OKTA", "false")
+	t.Setenv("TERRAFORM_NOBL9_FILES_PROMPT_ENABLED", "")
+	t.Setenv("TERRAFORM_NOBL9_FILES_PROMPT_THRESHOLD", "")
+	t.Setenv("TERRAFORM_NOBL9_PROJECT", "")
+	t.Setenv("TERRAFORM_NOBL9_URL", "")
+	t.Setenv("TERRAFORM_NOBL9_OKTA_ORG_URL", "")
+	t.Setenv("TERRAFORM_NOBL9_OKTA_AUTH_SERVER", "")
+	t.Setenv("TERRAFORM_NOBL9_ORGANIZATION", "")
+	t.Setenv("TERRAFORM_NOBL9_TIMEOUT", "")
+	t.Setenv("TERRAFORM_NOBL9_CA_CERT_FILE", "")
+}
+
+func unsetProviderConfigEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"NOBL9_CLIENT_ID",
+		"NOBL9_CLIENT_SECRET",
+		"NOBL9_OKTA_URL",
+		"NOBL9_OKTA_AUTH",
+		"NOBL9_PROJECT",
+		"NOBL9_URL",
+		"NOBL9_ORG",
+		"NOBL9_NO_CONFIG_FILE",
+	} {
+		unsetEnv(t, key)
 	}
 }
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -29,7 +29,13 @@ The Nobl9 Terraform Provider does not support the configuration of the following
 
 ## Configuration
 
-To start using Nobl9 Terraform Provider, you must configure the provider with the proper credentials. Then, use the navigation on the left to learn more about the available resources.
+Configure the provider with credentials in the provider block,
+`NOBL9_` environment variables,
+or the Nobl9 `config.toml` file.
+Provider arguments take precedence over environment variables,
+which take precedence over `config.toml`.
+Configuration-file loading is enabled by default.
+Set `no_config_file = true` to disable it.
 
 The following is an exemplary configuration:
 


### PR DESCRIPTION
## Motivation

When credentials are not provided through provider configuration or environment variables, the provider should use the existing `config.toml` credentials as a fallback.

## Summary

Changed `no_config_file` to default to `false` in both provider implementations. Provider arguments and `NOBL9_` environment variables keep their existing precedence, while missing or empty credentials now fall back to `config.toml`. Updated the provider documentation and generated reference.

## Testing

- `make test/unit`
- `GOFLAGS=-buildvcs=false make check` passed vet, lint, spelling, whitespace, Markdown, formatting, and generation; `check/vulns` reported the existing `GO-2026-6061` and `GO-2026-5970` dependency findings

## Release Notes

The provider now reads Nobl9 `config.toml` by default when credentials are not supplied through provider configuration or environment variables. Set `no_config_file = true` to disable this fallback.

## Breaking Changes

The default value of `no_config_file` changed from `true` to `false`, so an existing local `config.toml` file may now be read automatically.
