### PR TITLE
fix: handle unknown framework resource plans

### DIFF
--- a/internal/frameworkprovider/project_resource.go
+++ b/internal/frameworkprovider/project_resource.go
@@ -145,6 +145,9 @@ func (s *ProjectResource) ModifyPlan(
 	req resource.ModifyPlanRequest,
 	resp *resource.ModifyPlanResponse,
 ) {
+	if !req.Plan.Raw.IsFullyKnown() {
+		return
+	}
 	var plan *ProjectResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/frameworkprovider/resource_plan_test.go
+++ b/internal/frameworkprovider/resource_plan_test.go
@@ -1,0 +1,69 @@
+package frameworkprovider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResources_unknownValuesDuringPlanning(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "terraform_data" "name" {}
+
+resource "nobl9_project" "test" {
+  name = terraform_data.name.id
+}
+
+resource "nobl9_service" "test" {
+  name    = terraform_data.name.id
+  project = "default"
+}
+
+resource "nobl9_slo" "test" {
+  name             = terraform_data.name.id
+  project          = "default"
+  service          = "service"
+  budgeting_method = "Occurrences"
+
+  indicator {
+    name    = "indicator"
+    project = "default"
+    kind    = "Agent"
+  }
+
+  objective {
+    name   = "objective"
+    op     = "lt"
+    target = 0.7
+    value  = 1
+
+    raw_metric {
+      query {
+        appdynamics {
+          application_name = "application"
+          metric_path      = "metric"
+        }
+      }
+    }
+  }
+
+  time_window {
+    count      = 10
+    is_rolling = true
+    unit       = "Minute"
+  }
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/internal/frameworkprovider/service_resource.go
+++ b/internal/frameworkprovider/service_resource.go
@@ -205,6 +205,9 @@ func (s *ServiceResource) ModifyPlan(
 	req resource.ModifyPlanRequest,
 	resp *resource.ModifyPlanResponse,
 ) {
+	if !req.Plan.Raw.IsFullyKnown() {
+		return
+	}
 	var plan *ServiceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -199,6 +199,9 @@ func (s *SLOResource) ModifyPlan(
 	req resource.ModifyPlanRequest,
 	resp *resource.ModifyPlanResponse,
 ) {
+	if !req.Plan.Raw.IsFullyKnown() {
+		return
+	}
 	var plan *SLOResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
## Motivation

Migrated Project, Service, and SLO resources fail during planning when any planned value is unknown. Their resource-level validation decodes the complete plan into models containing native Go fields before Terraform has resolved dependencies, producing a `Value Conversion Error`.

## Summary

Deferred API dry-run validation while a resource plan contains unknown values. Fully known plans continue to use the existing API validation path.

## Testing

The issue can be reproduced with this minimal configuration:

```hcl
resource "terraform_data" "name" {}

resource "nobl9_project" "this" {
  name = terraform_data.name.id
}
```

Before this change, `terraform plan` returned this diagnostic:

```text
Error: Value Conversion Error

An unexpected error was encountered trying to build a value. This is always
an error in the provider. Please report the following to the provider
developer:

Received unknown value, however the target type cannot handle unknown values.
Use the corresponding `types` package type or a custom type that handles
unknown values.

Path: name
Target Type: string
Suggested Type: basetypes.StringValue
```

After this change, Terraform can plan the dependency and validates the Nobl9 resource once its values are known.

Added acceptance coverage that plans Project, Service, and SLO resources with unknown names. Existing known-value plan-validation acceptance coverage also passed.

## Release Notes

Fixed planning for Project, Service, and SLO resources whose configurations contain values that are not known until apply.
