### PR TITLE
fix: preserve explicit empty metadata

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
     "sloctl",
     "slos",
     "tffile",
+    "tfjsonpath",
     "tflog",
     "tfplugindocs",
     "tfprotov",

--- a/internal/frameworkprovider/helpers.go
+++ b/internal/frameworkprovider/helpers.go
@@ -24,6 +24,20 @@ func stringValue(v string) types.String {
 	return types.StringValue(v)
 }
 
+func preserveExplicitEmptyString(source, target types.String) types.String {
+	if !source.IsNull() && !source.IsUnknown() && source.ValueString() == "" && target.IsNull() {
+		return source
+	}
+	return target
+}
+
+func preserveExplicitEmptyAnnotations(source, target map[string]string) map[string]string {
+	if source != nil && len(source) == 0 && target == nil {
+		return source
+	}
+	return target
+}
+
 // valueFromPointer returns the value pointed to by the pointer v.
 // If v is nil, it returns the zero value of type T.
 func valueFromPointer[T any](v *T) (dereference T) {

--- a/internal/frameworkprovider/project_resource.go
+++ b/internal/frameworkprovider/project_resource.go
@@ -192,6 +192,9 @@ func (s *ProjectResource) readResource(
 		return nil, diagnostics
 	}
 	updatedModel := newProjectResourceConfigFromManifest(project)
+	updatedModel.DisplayName = preserveExplicitEmptyString(model.DisplayName, updatedModel.DisplayName)
+	updatedModel.Description = preserveExplicitEmptyString(model.Description, updatedModel.Description)
+	updatedModel.Annotations = preserveExplicitEmptyAnnotations(model.Annotations, updatedModel.Annotations)
 	// Sort Labels.
 	updatedModel.Labels = sortLabels(model.Labels, updatedModel.Labels)
 	return updatedModel, diagnostics

--- a/internal/frameworkprovider/project_resource_test.go
+++ b/internal/frameworkprovider/project_resource_test.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/nobl9/nobl9-go/manifest"
 	v1alphaProject "github.com/nobl9/nobl9-go/manifest/v1alpha/project"
 	"github.com/nobl9/nobl9-go/tests/e2etestutils"
@@ -123,6 +126,41 @@ func TestAccProjectResource(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccProjectResource_explicitEmptyMetadata(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	projectResource := projectResourceTemplateModel{
+		ResourceName: "test",
+		ProjectResourceModel: ProjectResourceModel{
+			Name:        e2etestutils.GenerateName(),
+			DisplayName: types.StringValue(""),
+			Description: types.StringValue(""),
+			Annotations: map[string]string{},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: newProjectResource(t, projectResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_project.test", "display_name", ""),
+					resource.TestCheckResourceAttr("nobl9_project.test", "description", ""),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"nobl9_project.test",
+						tfjsonpath.New("annotations"),
+						knownvalue.MapExact(map[string]knownvalue.Check{}),
+					),
+				},
+			},
 		},
 	})
 }

--- a/internal/frameworkprovider/service_resource.go
+++ b/internal/frameworkprovider/service_resource.go
@@ -252,6 +252,9 @@ func (s *ServiceResource) readResource(
 		return nil, diagnostics
 	}
 	updatedModel := newServiceResourceConfigFromManifest(service)
+	updatedModel.DisplayName = preserveExplicitEmptyString(model.DisplayName, updatedModel.DisplayName)
+	updatedModel.Description = preserveExplicitEmptyString(model.Description, updatedModel.Description)
+	updatedModel.Annotations = preserveExplicitEmptyAnnotations(model.Annotations, updatedModel.Annotations)
 	// Sort Labels.
 	updatedModel.Labels = sortLabels(model.Labels, updatedModel.Labels)
 	updatedModel.ResponsibleUsers = sortResponsibleUsers(model.ResponsibleUsers, updatedModel.ResponsibleUsers)

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/nobl9/nobl9-go/manifest"
 	v1alphaService "github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 	"github.com/nobl9/nobl9-go/tests/e2etestutils"
@@ -171,6 +174,47 @@ func TestAccServiceResource(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccServiceResource_explicitEmptyMetadata(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	project := getExampleProjectResource(t).ToManifest()
+	serviceResource := serviceResourceTemplateModel{
+		ResourceName: "test",
+		ServiceResourceModel: ServiceResourceModel{
+			Name:        e2etestutils.GenerateName(),
+			DisplayName: types.StringValue(""),
+			Project:     project.GetName(),
+			Description: types.StringValue(""),
+			Annotations: map[string]string{},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, []manifest.Object{project})
+					t.Cleanup(func() { e2etestutils.V1Delete(t, []manifest.Object{project}) })
+				},
+				Config: newServiceResource(t, serviceResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_service.test", "display_name", ""),
+					resource.TestCheckResourceAttr("nobl9_service.test", "description", ""),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"nobl9_service.test",
+						tfjsonpath.New("annotations"),
+						knownvalue.MapExact(map[string]knownvalue.Check{}),
+					),
+				},
+			},
 		},
 	})
 }

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -253,6 +253,9 @@ func (s *SLOResource) readResource(
 		return nil, diagnostics
 	}
 	updatedModel := newSLOResourceConfigFromManifest(slo)
+	updatedModel.DisplayName = preserveExplicitEmptyString(model.DisplayName, updatedModel.DisplayName)
+	updatedModel.Description = preserveExplicitEmptyString(model.Description, updatedModel.Description)
+	updatedModel.Annotations = preserveExplicitEmptyAnnotations(model.Annotations, updatedModel.Annotations)
 	s.updateEmptyAlertPolicies(ctx, diagnostics, state, plan, updatedModel, slo)
 	s.updateEmptyCompositeAggregation(ctx, state, plan, updatedModel)
 	s.sortLists(model, updatedModel)

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	v1alphaAlertMethod "github.com/nobl9/nobl9-go/manifest/v1alpha/alertmethod"
@@ -175,6 +178,57 @@ func TestAccSLOResource(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccSLOResource_explicitEmptyMetadata(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	project := getExampleProjectResource(t).ToManifest()
+	service := getExampleServiceResource(t).ToManifest()
+	service.Metadata.Project = project.GetName()
+	direct := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.DisplayName = types.StringValue("")
+	sloResource.Project = project.GetName()
+	sloResource.Description = types.StringValue("")
+	sloResource.Annotations = map[string]string{}
+	sloResource.Service = service.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    direct.GetName(),
+		Project: types.StringValue(direct.GetProject()),
+		Kind:    types.StringValue(direct.GetKind().String()),
+	}}
+
+	auxiliaryObjects := []manifest.Object{project, service}
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, auxiliaryObjects)
+					t.Cleanup(func() { e2etestutils.V1Delete(t, auxiliaryObjects) })
+				},
+				Config: newSLOResource(t, sloResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "display_name", ""),
+					resource.TestCheckResourceAttr("nobl9_slo.test", "description", ""),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"nobl9_slo.test",
+						tfjsonpath.New("annotations"),
+						knownvalue.MapExact(map[string]knownvalue.Check{}),
+					),
+				},
+			},
 		},
 	})
 }

--- a/internal/frameworkprovider/test_data/templates/common.hcl.tmpl
+++ b/internal/frameworkprovider/test_data/templates/common.hcl.tmpl
@@ -6,7 +6,7 @@
   {{- if hasField "Project" . }}
   project = "{{ .Project }}"
   {{- end }}
-  {{- if .Annotations }}
+  {{- if not (eq .Annotations nil) }}
   annotations = {
     {{- range $key, $value := .Annotations }}
     {{ $key }} = "{{ $value }}",


### PR DESCRIPTION
## Motivation

Migrated resources convert API empty metadata values to `null`. Terraform then reports an inconsistent result when the configuration explicitly sets those values to empty strings or an empty map.

## Summary

Preserve explicitly configured empty `display_name`, `description`, and `annotations` values for Project, Service, and SLO resources. Omitted and non-empty values keep their existing behavior.

## Testing

Minimal reproducer:

```hcl
resource "nobl9_project" "this" {
  name         = "example-project"
  display_name = ""
  description  = ""
  annotations  = {}
}
```

Before this change, the combined reproduction returned these diagnostics:

```text
Error: Provider produced inconsistent result after apply

new value: .description: was cty.StringVal(""), but now null.

Error: Provider produced inconsistent result after apply

new value: .display_name: was cty.StringVal(""), but now null.
```

With only `annotations = {}` configured explicitly, the same regression returned:

```text
Error: Provider produced inconsistent result after apply

new value: .annotations: was cty.MapValEmpty(cty.String), but now null.
```

After this change, the apply succeeds and the explicit empty values remain known in state.

Acceptance tests cover Project, Service, and SLO resources, including an exact known empty annotations map.

## Release Notes

Fixed Project, Service, and SLO configurations that explicitly set empty metadata values.
