### PR TITLE
fix: recover externally deleted framework resources

### DIFF
--- a/internal/frameworkprovider/project_resource.go
+++ b/internal/frameworkprovider/project_resource.go
@@ -72,13 +72,18 @@ func (s *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	// Read the Project after update to fetch the computed fields.
-	updatedModel, diags := s.readResource(ctx, model)
+	project, found, diags := s.client.FindProject(ctx, model.Name)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
+	updatedModel := newProjectResourceConfigFromManifest(project)
+	updatedModel.Labels = sortLabels(model.Labels, updatedModel.Labels)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedModel)...)
 }
 

--- a/internal/frameworkprovider/project_resource_test.go
+++ b/internal/frameworkprovider/project_resource_test.go
@@ -149,6 +149,44 @@ func TestAccProjectResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccProjectResource_externalDeletion(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	projectResource := projectResourceTemplateModel{
+		ResourceName:         "test",
+		ProjectResourceModel: getExampleProjectResource(t),
+	}
+	manifestProject := projectResource.ToManifest()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: newProjectResource(t, projectResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestProject),
+				),
+			},
+			{
+				PreConfig: func() {
+					e2etestutils.V1Delete(t, []manifest.Object{manifestProject})
+				},
+				Config: newProjectResource(t, projectResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestProject),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_project.test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestRenderProjectResourceTemplate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -177,12 +177,33 @@ func (s sdkClient) GetService(ctx context.Context, name, project string) (v1alph
 	return genericGetObject[v1alphaService.Service](ctx, s.client, manifest.KindService, name, project)
 }
 
+func (s sdkClient) FindService(
+	ctx context.Context,
+	name, project string,
+) (v1alphaService.Service, bool, diag.Diagnostics) {
+	return genericFindObject[v1alphaService.Service](ctx, s.client, manifest.KindService, name, project)
+}
+
 func (s sdkClient) GetProject(ctx context.Context, name string) (v1alphaProject.Project, diag.Diagnostics) {
 	return genericGetObject[v1alphaProject.Project](ctx, s.client, manifest.KindProject, name, "")
 }
 
+func (s sdkClient) FindProject(
+	ctx context.Context,
+	name string,
+) (v1alphaProject.Project, bool, diag.Diagnostics) {
+	return genericFindObject[v1alphaProject.Project](ctx, s.client, manifest.KindProject, name, "")
+}
+
 func (s sdkClient) GetSLO(ctx context.Context, name, project string) (v1alphaSLO.SLO, diag.Diagnostics) {
 	return genericGetObject[v1alphaSLO.SLO](ctx, s.client, manifest.KindSLO, name, project)
+}
+
+func (s sdkClient) FindSLO(
+	ctx context.Context,
+	name, project string,
+) (v1alphaSLO.SLO, bool, diag.Diagnostics) {
+	return genericFindObject[v1alphaSLO.SLO](ctx, s.client, manifest.KindSLO, name, project)
 }
 
 // Replay runs historical data retrieval for the given SLO.
@@ -238,6 +259,23 @@ func genericGetObject[T manifest.Object](
 	kind manifest.Kind,
 	name, project string,
 ) (typed T, diags diag.Diagnostics) {
+	typed, found, diags := genericFindObject[T](ctx, client, kind, name, project)
+	if diags.HasError() || found {
+		return typed, diags
+	}
+	diags.AddError(
+		fmt.Sprintf("Failed to get %s %s", manifest.VersionV1alpha, kind),
+		"unexpected number of objects in response, expected 1, got 0",
+	)
+	return typed, diags
+}
+
+func genericFindObject[T manifest.Object](
+	ctx context.Context,
+	client *sdk.Client,
+	kind manifest.Kind,
+	name, project string,
+) (typed T, found bool, diags diag.Diagnostics) {
 	header := http.Header{}
 	if project != "" {
 		header.Add(sdk.HeaderProject, project)
@@ -249,12 +287,15 @@ func genericGetObject[T manifest.Object](
 		url.Values{v1Objects.QueryKeyName: []string{name}},
 	)
 	if err != nil {
-		return typed, diag.Diagnostics{
+		return typed, false, diag.Diagnostics{
 			diag.NewErrorDiagnostic(fmt.Sprintf("Failed to get %s %s", manifest.VersionV1alpha, kind), err.Error()),
 		}
 	}
+	if len(objects) == 0 {
+		return typed, false, nil
+	}
 	if len(objects) != 1 {
-		return typed, diag.Diagnostics{
+		return typed, false, diag.Diagnostics{
 			diag.NewErrorDiagnostic(
 				fmt.Sprintf("Failed to get %s %s", manifest.VersionV1alpha, kind),
 				fmt.Sprintf("unexpected number of objects in response, expected 1, got %d", len(objects))),
@@ -265,13 +306,13 @@ func genericGetObject[T manifest.Object](
 	var ok bool
 	typed, ok = obj.(T)
 	if !ok {
-		return typed, diag.Diagnostics{
+		return typed, false, diag.Diagnostics{
 			diag.NewErrorDiagnostic(
 				fmt.Sprintf("Failed to cast %T to %T", obj, typed),
 				"Please report this issue to the provider developers."),
 		}
 	}
-	return typed, nil
+	return typed, true, nil
 }
 
 func getManifestObjectTraceAttrs(obj manifest.Object) map[string]any {

--- a/internal/frameworkprovider/service_resource.go
+++ b/internal/frameworkprovider/service_resource.go
@@ -124,13 +124,19 @@ func (s *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	// Read the Service after update to fetch the computed fields.
-	updatedModel, diags := s.readResource(ctx, model)
+	service, found, diags := s.client.FindService(ctx, model.Name, model.Project)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
+	updatedModel := newServiceResourceConfigFromManifest(service)
+	updatedModel.Labels = sortLabels(model.Labels, updatedModel.Labels)
+	updatedModel.ResponsibleUsers = sortResponsibleUsers(model.ResponsibleUsers, updatedModel.ResponsibleUsers)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedModel)...)
 }
 

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -391,6 +391,52 @@ func TestAccServiceResource_ReviewCycle(t *testing.T) {
 	})
 }
 
+func TestAccServiceResource_externalDeletion(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	serviceResource := serviceResourceTemplateModel{
+		ResourceName:         "test",
+		ServiceResourceModel: getExampleServiceResource(t),
+	}
+	serviceResource.Project = manifestProject.GetName()
+	manifestService := serviceResource.ToManifest()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, []manifest.Object{manifestProject})
+					t.Cleanup(func() {
+						e2etestutils.V1Delete(t, []manifest.Object{manifestProject})
+					})
+				},
+				Config: newServiceResource(t, serviceResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestService),
+				),
+			},
+			{
+				PreConfig: func() {
+					e2etestutils.V1Delete(t, []manifest.Object{manifestService})
+				},
+				Config: newServiceResource(t, serviceResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestService),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_service.test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestRenderServiceResourceTemplate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -77,13 +77,20 @@ func (s *SLOResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	// Read the SLO after update to fetch the computed fields.
-	updatedModel, diags := s.readResource(ctx, req.State, nil, &model)
+	slo, found, diags := s.client.FindSLO(ctx, model.Name, model.Project)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
+	updatedModel := newSLOResourceConfigFromManifest(slo)
+	s.updateEmptyAlertPolicies(ctx, resp.Diagnostics, req.State, nil, updatedModel, slo)
+	s.updateEmptyCompositeAggregation(ctx, req.State, nil, updatedModel)
+	s.sortLists(&model, updatedModel)
 	diags = resp.State.Set(ctx, &updatedModel)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -1654,6 +1654,64 @@ func TestAccSLOResource_examples(t *testing.T) {
 	}
 }
 
+func TestAccSLOResource_externalDeletion(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	manifestService := getExampleServiceResource(t).ToManifest()
+	manifestService.Metadata.Project = manifestProject.GetName()
+	auxiliaryObjects := []manifest.Object{manifestProject, manifestService}
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = manifestProject.GetName()
+	sloResource.Service = manifestService.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+	manifestSLO := sloResource.ToManifest()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, auxiliaryObjects)
+					t.Cleanup(func() {
+						e2etestutils.V1Delete(t, auxiliaryObjects)
+					})
+				},
+				Config: newSLOResource(t, sloResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestSLO),
+				),
+			},
+			{
+				PreConfig: func() {
+					e2etestutils.V1Delete(t, []manifest.Object{manifestSLO})
+				},
+				Config: newSLOResource(t, sloResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestSLO),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestRenderSLOResourceTemplate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

When a migrated Project, Service, or SLO is deleted outside Terraform, refresh returns an error instead of removing the missing object from state. Terraform therefore cannot plan its recreation.

## Summary

Treat an empty API lookup during resource refresh as a missing remote object and remove it from Terraform state. API errors, ambiguous responses, and type errors remain diagnostics.

## Testing

Minimal reproducer:

```hcl
resource "nobl9_project" "this" {
  name = "example-project"
}
```

Apply the configuration, delete the Project outside Terraform through the Nobl9 API, then run `terraform plan`. Before this change, refresh returned:

```text
Error: Failed to get n9/v1alpha Project

unexpected number of objects in response, expected 1, got 0
```

After this change, the plan contains a create action for the missing Project.

Acceptance tests perform the external deletion and verify recreation plans for Project, Service, and SLO resources.

## Release Notes

Fixed refresh and recreation of migrated Project, Service, and SLO resources deleted outside Terraform.
