### PR TITLE
fix: restore single-name framework imports

### DIFF
--- a/internal/frameworkprovider/helpers.go
+++ b/internal/frameworkprovider/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -77,6 +78,19 @@ func addInvalidSDKClientTypeDiag(diags *diag.Diagnostics, data any) {
 			data,
 		),
 	)
+}
+
+func parseProjectScopedImportID(id, defaultProject string) (project, name string, ok bool) {
+	parts := strings.Split(id, "/")
+	switch len(parts) {
+	case 1:
+		project, name = defaultProject, parts[0]
+	case 2:
+		project, name = parts[0], parts[1]
+	default:
+		return "", "", false
+	}
+	return project, name, project != "" && name != ""
 }
 
 func deepCopy[T any](t *testing.T, v T) (cp T) {

--- a/internal/frameworkprovider/provider_test.go
+++ b/internal/frameworkprovider/provider_test.go
@@ -206,6 +206,32 @@ func assertResourceWasDeleted(t *testing.T, ctx context.Context, expected manife
 	}
 }
 
+func cleanupObjectsIfPresent(t *testing.T, ctx context.Context, objects []manifest.Object) {
+	t.Helper()
+
+	for _, object := range objects {
+		headers := http.Header{}
+		project := ""
+		if projectScoped, ok := object.(manifest.ProjectScopedObject); ok {
+			project = projectScoped.GetProject()
+			headers.Set(sdk.HeaderProject, project)
+		}
+		params := url.Values{v1Objects.QueryKeyName: []string{object.GetName()}}
+		found, err := testSDKClient.client.Objects().V1().Get(ctx, object.GetKind(), headers, params)
+		require.NoError(t, err)
+		if len(found) == 0 {
+			continue
+		}
+		require.Len(t, found, 1)
+		require.NoError(t, testSDKClient.client.Objects().V1().DeleteByName(
+			ctx,
+			object.GetKind(),
+			project,
+			object.GetName(),
+		))
+	}
+}
+
 func getObjectsFromTheNobl9API(t *testing.T, ctx context.Context, object manifest.Object) ([]manifest.Object, error) {
 	t.Helper()
 

--- a/internal/frameworkprovider/service_resource.go
+++ b/internal/frameworkprovider/service_resource.go
@@ -2,7 +2,6 @@ package frameworkprovider
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -167,15 +166,16 @@ func (s *ServiceResource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	parts := strings.Split(req.ID, "/")
-	if len(parts) != 2 {
+	project, name, ok := parseProjectScopedImportID(req.ID, s.client.client.Config.Project)
+	if !ok {
 		resp.Diagnostics.AddError(
 			"Invalid import ID",
-			"Expected ID to be in the format '<project-name>/<service-name>'.",
+			"Expected ID to be in the format '<service-name>' or '<project-name>/<service-name>'. "+
+				"Importing by Service name requires a default Project in the provider configuration.",
 		)
 		return
 	}
-	model, diags := s.readResource(ctx, ServiceResourceModel{Name: parts[1], Project: parts[0]})
+	model, diags := s.readResource(ctx, ServiceResourceModel{Name: name, Project: project})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -14,6 +14,7 @@ import (
 	v1alphaService "github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 	"github.com/nobl9/nobl9-go/tests/e2etestutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccServiceResource(t *testing.T) {
@@ -69,14 +70,28 @@ func TestAccServiceResource(t *testing.T) {
 				},
 				Destroy: true,
 			},
-			// 3. ImportState - invalid id.
+			// 3. ImportState - invalid ID with leading empty segment.
 			{
 				ResourceName:  "nobl9_service.test",
-				ImportStateId: serviceResource.Name,
+				ImportStateId: "/" + serviceResource.Name,
 				ImportState:   true,
 				ExpectError:   regexp.MustCompile(`Invalid import ID`),
 			},
-			// 4. ImportState.
+			// 4. ImportState - invalid ID with trailing empty segment.
+			{
+				ResourceName:  "nobl9_service.test",
+				ImportStateId: serviceResource.Project + "/",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile(`Invalid import ID`),
+			},
+			// 5. ImportState - invalid ID with an extra segment.
+			{
+				ResourceName:  "nobl9_service.test",
+				ImportStateId: serviceResource.Project + "/" + serviceResource.Name + "/extra",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile(`Invalid import ID`),
+			},
+			// 6. ImportState.
 			{
 				ResourceName:  "nobl9_service.test",
 				ImportStateId: serviceResource.Project + "/" + serviceResource.Name,
@@ -93,7 +108,7 @@ func TestAccServiceResource(t *testing.T) {
 				ImportStatePersist: true,
 				PreConfig:          func() { e2etestutils.V1Apply(t, []manifest.Object{serviceResource.ToManifest()}) },
 			},
-			// 5. Update and Read, ensure computed field does not pollute the plan.
+			// 7. Update and Read, ensure computed field does not pollute the plan.
 			{
 				Config: newServiceResource(t, func() serviceResourceTemplateModel {
 					m := serviceResource
@@ -117,7 +132,7 @@ func TestAccServiceResource(t *testing.T) {
 					},
 				},
 			},
-			// 6. Update name and revert display name - recreate.
+			// 8. Update name and revert display name - recreate.
 			{
 				Config: newServiceResource(t, func() serviceResourceTemplateModel {
 					m := serviceResource
@@ -143,7 +158,7 @@ func TestAccServiceResource(t *testing.T) {
 					},
 				},
 			},
-			// 7. Update project - recreate.
+			// 9. Update project - recreate.
 			{
 				Config: newServiceResource(t, func() serviceResourceTemplateModel {
 					m := serviceResource
@@ -171,6 +186,58 @@ func TestAccServiceResource(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccServiceResource_singleNameImport(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	defaultProject := testSDKClient.client.Config.Project
+	require.NotEmpty(t, defaultProject)
+
+	serviceResource := serviceResourceTemplateModel{
+		ResourceName:         "test",
+		ServiceResourceModel: getExampleServiceResource(t),
+	}
+	serviceResource.Project = defaultProject
+	manifestService := serviceResource.ToManifest()
+	config := newServiceResource(t, serviceResource)
+	cleanupContext := context.WithoutCancel(t.Context())
+	t.Cleanup(func() {
+		cleanupObjectsIfPresent(t, cleanupContext, []manifest.Object{manifestService})
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName:       "nobl9_service.test",
+				Config:             config,
+				ImportStateId:      serviceResource.Name,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if !assert.Len(t, states, 1) {
+						return errors.New("expected exactly one state")
+					}
+					assert.Equal(t, serviceResource.Name, states[0].Attributes["name"])
+					assert.Equal(t, defaultProject, states[0].Attributes["project"])
+					return nil
+				},
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, []manifest.Object{manifestService})
+				},
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 		},
 	})
 }

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -3,7 +3,6 @@ package frameworkprovider
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -161,15 +160,16 @@ func (s *SLOResource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	parts := strings.Split(req.ID, "/")
-	if len(parts) != 2 {
+	project, name, ok := parseProjectScopedImportID(req.ID, s.client.client.Config.Project)
+	if !ok {
 		resp.Diagnostics.AddError(
 			"Invalid import ID",
-			"Expected ID to be in the format '<project-name>/<slo-name>'.",
+			"Expected ID to be in the format '<slo-name>' or '<project-name>/<slo-name>'. "+
+				"Importing by SLO name requires a default Project in the provider configuration.",
 		)
 		return
 	}
-	model, diags := s.readResource(ctx, resp.State, nil, &SLOResourceModel{Name: parts[1], Project: parts[0]})
+	model, diags := s.readResource(ctx, resp.State, nil, &SLOResourceModel{Name: name, Project: project})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -101,14 +101,28 @@ func TestAccSLOResource(t *testing.T) {
 				},
 				Destroy: true,
 			},
-			// 3. ImportState - invalid id.
+			// 3. ImportState - invalid ID with leading empty segment.
 			{
 				ResourceName:  "nobl9_slo.test",
-				ImportStateId: sloResource.Name,
+				ImportStateId: "/" + sloResource.Name,
 				ImportState:   true,
 				ExpectError:   regexp.MustCompile(`Invalid import ID`),
 			},
-			// 4. ImportState.
+			// 4. ImportState - invalid ID with trailing empty segment.
+			{
+				ResourceName:  "nobl9_slo.test",
+				ImportStateId: sloResource.Project + "/",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile(`Invalid import ID`),
+			},
+			// 5. ImportState - invalid ID with an extra segment.
+			{
+				ResourceName:  "nobl9_slo.test",
+				ImportStateId: sloResource.Project + "/" + sloResource.Name + "/extra",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile(`Invalid import ID`),
+			},
+			// 6. ImportState.
 			{
 				ResourceName:  "nobl9_slo.test",
 				Config:        sloConfig,
@@ -128,7 +142,7 @@ func TestAccSLOResource(t *testing.T) {
 					e2etestutils.V1Apply(t, []manifest.Object{manifestSLO})
 				},
 			},
-			// 5. Update and Read, ensure computed fields do not pollute the plan.
+			// 7. Update and Read, ensure computed fields do not pollute the plan.
 			{
 				Config: newSLOResource(t, func() sloResourceTemplateModel {
 					m := sloResource
@@ -151,7 +165,7 @@ func TestAccSLOResource(t *testing.T) {
 					},
 				},
 			},
-			// 6. Update name and revert display name - recreate.
+			// 8. Update name and revert display name - recreate.
 			{
 				Config: newSLOResource(t, func() sloResourceTemplateModel {
 					m := sloResource
@@ -175,6 +189,69 @@ func TestAccSLOResource(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccSLOResource_singleNameImport(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	defaultProject := testSDKClient.client.Config.Project
+	require.NotEmpty(t, defaultProject)
+
+	manifestService := getExampleServiceResource(t).ToManifest()
+	manifestService.Metadata.Project = defaultProject
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = defaultProject
+	sloResource.Service = manifestService.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+	manifestSLO := sloResource.ToManifest()
+	config := newSLOResource(t, sloResource)
+	cleanupContext := context.WithoutCancel(t.Context())
+	t.Cleanup(func() {
+		cleanupObjectsIfPresent(t, cleanupContext, []manifest.Object{manifestSLO, manifestService})
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName:       "nobl9_slo.test",
+				Config:             config,
+				ImportStateId:      sloResource.Name,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if !assert.Len(t, states, 1) {
+						return errors.New("expected exactly one state")
+					}
+					assert.Equal(t, sloResource.Name, states[0].Attributes["name"])
+					assert.Equal(t, defaultProject, states[0].Attributes["project"])
+					return nil
+				},
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, []manifest.Object{manifestService, manifestSLO})
+				},
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Motivation

The framework Service and SLO resources rejected the legacy single-name import form even when the provider had a default Project configured. This was a migration regression from the SDK resources, which accepted both `<name>` and `<project>/<name>`.

## Summary

- Accepted either a single resource name or a fully qualified Project/name import ID.
- Resolved single-name imports against the provider's configured default Project.
- Rejected empty and over-qualified import IDs with resource-specific diagnostics.
- Added acceptance coverage for both supported forms and malformed IDs.

## Testing

Minimal configuration:

```hcl
provider "nobl9" {
  project = "example-project"
}

resource "nobl9_service" "this" {
  name    = "example-service"
  project = "example-project"
}
```

After applying the configuration, remove the resource from state and import it using only its name:

```console
terraform state rm nobl9_service.this
terraform import nobl9_service.this example-service
terraform plan
```

Before this change, the import returned:

```text
Error: Invalid import ID

Expected ID to be in the format '<project-name>/<service-name>'.
```

The updated provider completed the single-name import with an empty final plan. Acceptance coverage exercised the same workflow for both Service and SLO resources, fully qualified imports, and invalid leading, trailing, or extra path segments.

## Release Notes

Restored importing Service and SLO resources by name when the provider has a default Project configured.
