### PR TITLE
fix: detach alert policies while moving SLO

### DIFF
--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -211,12 +211,17 @@ func (s sdkClient) Replay(ctx context.Context, payload sdkModels.Replay) error {
 	return err
 }
 
-func (s sdkClient) MoveSLOs(ctx context.Context, sloName, oldProject, newProject, newService string) diag.Diagnostics {
+func (s sdkClient) MoveSLOs(
+	ctx context.Context,
+	sloName, oldProject, newProject, newService string,
+	detachAlertPolicies bool,
+) diag.Diagnostics {
 	err := s.client.Objects().V1().MoveSLOs(ctx, v1Objects.MoveSLOsRequest{
-		SLONames:   []string{sloName},
-		OldProject: oldProject,
-		NewProject: newProject,
-		Service:    newService,
+		SLONames:            []string{sloName},
+		OldProject:          oldProject,
+		NewProject:          newProject,
+		Service:             newService,
+		DetachAlertPolicies: detachAlertPolicies,
 	})
 	if err != nil {
 		return diag.Diagnostics{

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -105,10 +105,23 @@ func (s *SLOResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var sourceAlertPolicies []string
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("alert_policies"), &sourceAlertPolicies)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
+	detachAlertPolicies := len(sourceAlertPolicies) > 0 && len(model.AlertPolicies) == 0
 	moveSLO := model.Project != sourceProject
 	if moveSLO {
-		resp.Diagnostics.Append(s.client.MoveSLOs(ctx, model.Name, sourceProject, model.Project, model.Service)...)
+		resp.Diagnostics.Append(s.client.MoveSLOs(
+			ctx,
+			model.Name,
+			sourceProject,
+			model.Project,
+			model.Service,
+			detachAlertPolicies,
+		)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -116,9 +129,7 @@ func (s *SLOResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	moveSLOUpdateWarningFunc := func() {
 		if moveSLO {
 			resp.Diagnostics.AddWarning("SLO Update Warning",
-				"SLO definition update failed, but the SLO was moved to a new project."+
-					"\nResolve the issues and retry the update operation,"+
-					" bear in mind that the SLO will remain in the new project.")
+				sloMovePartialSuccessWarningDetail(detachAlertPolicies))
 		}
 	}
 
@@ -133,6 +144,16 @@ func (s *SLOResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		moveSLOUpdateWarningFunc()
 		return
 	}
+}
+
+func sloMovePartialSuccessWarningDetail(detachAlertPolicies bool) string {
+	detail := "SLO definition update failed, but the SLO was moved to a new project."
+	if detachAlertPolicies {
+		detail += " Its Alert Policies were also detached."
+	}
+	return detail +
+		"\nTerraform state may be stale. Refresh and re-plan before resolving the issues" +
+		" and retrying the update operation. Bear in mind that the SLO will remain in the new project."
 }
 
 // Delete is called when the provider must delete the resource. Config

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -654,6 +654,9 @@ func TestAccSLOResource_moveSLOAndDetachAlertPolicies(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, targetAuxiliaryObjects)
+				},
 				Config: newSLOResource(t, func() sloResourceTemplateModel {
 					m := sloResource
 					m.Project = newProjectName
@@ -1977,35 +1980,6 @@ func TestRenderSLOResourceTemplate_compositeV1Example(t *testing.T) {
 
 	assertHCL(t, actual)
 	assert.Equal(t, readExpectedConfig(t, "slo-composite-v1-config.tf"), actual)
-}
-
-func Test_sloMovePartialSuccessWarningDetail(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]struct {
-		detachAlertPolicies bool
-		expected            string
-	}{
-		"moved without detaching alert policies": {
-			expected: "SLO definition update failed, but the SLO was moved to a new project." +
-				"\nTerraform state may be stale. Refresh and re-plan before resolving the issues" +
-				" and retrying the update operation. Bear in mind that the SLO will remain in the new project.",
-		},
-		"moved and detached alert policies": {
-			detachAlertPolicies: true,
-			expected: "SLO definition update failed, but the SLO was moved to a new project." +
-				" Its Alert Policies were also detached." +
-				"\nTerraform state may be stale. Refresh and re-plan before resolving the issues" +
-				" and retrying the update operation. Bear in mind that the SLO will remain in the new project.",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, test.expected, sloMovePartialSuccessWarningDetail(test.detachAlertPolicies))
-		})
-	}
 }
 
 func deleteSLOsIfPresent(t *testing.T, ctx context.Context, slos ...v1alphaSLO.SLO) {

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -658,13 +658,13 @@ func TestAccSLOResource_moveSLOAndDetachAlertPolicies(t *testing.T) {
 					m := sloResource
 					m.Project = newProjectName
 					m.Service = newServiceName
-					m.AlertPolicies = nil
+					m.AlertPolicies = []string{}
 					return m
 				}()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("nobl9_slo.test", "project", newProjectName),
 					resource.TestCheckResourceAttr("nobl9_slo.test", "service", newServiceName),
-					resource.TestCheckNoResourceAttr("nobl9_slo.test", "alert_policies"),
+					resource.TestCheckResourceAttr("nobl9_slo.test", "alert_policies.#", "0"),
 					assertResourceWasApplied(t, ctx, movedManifestSLO),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -577,6 +578,105 @@ func TestAccSLOResource_moveSLO(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccSLOResource_moveSLOAndDetachAlertPolicies(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+	ctx := t.Context()
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	manifestService := getExampleServiceResource(t).ToManifest()
+	manifestService.Metadata.Project = manifestProject.GetName()
+
+	manifestAlertPolicy := e2etestutils.GetExampleObject[v1alphaAlertPolicy.AlertPolicy](
+		t,
+		manifest.KindAlertPolicy,
+		nil,
+	)
+	manifestAlertPolicy.Metadata.Name = e2etestutils.GenerateName()
+	manifestAlertPolicy.Metadata.Project = manifestProject.GetName()
+	manifestAlertPolicy.Metadata.Labels = e2etestutils.AnnotateLabels(t, nil)
+	manifestAlertPolicy.Spec.AlertMethods = nil
+
+	auxiliaryObjects := []manifest.Object{manifestProject, manifestService, manifestAlertPolicy}
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = manifestProject.GetName()
+	sloResource.Service = manifestService.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+	sloResource.AlertPolicies = []string{manifestAlertPolicy.GetName()}
+
+	manifestSLO := sloResource.ToManifest()
+	newProjectName := e2etestutils.GenerateName()
+	newServiceName := e2etestutils.GenerateName()
+
+	newProjectManifest := manifestProject
+	newProjectManifest.Metadata.Name = newProjectName
+	newServiceManifest := manifestService
+	newServiceManifest.Metadata.Project = newProjectName
+	newServiceManifest.Metadata.Name = newServiceName
+	targetAuxiliaryObjects := []manifest.Object{newProjectManifest, newServiceManifest}
+
+	movedManifestSLO := manifestSLO
+	movedManifestSLO.Metadata.Project = newProjectName
+	movedManifestSLO.Spec.Service = newServiceName
+	movedManifestSLO.Spec.AlertPolicies = nil
+
+	// Cleanup callbacks run in reverse registration order.
+	t.Cleanup(func() { e2etestutils.V1Delete(t, auxiliaryObjects) })
+	t.Cleanup(func() { e2etestutils.V1Delete(t, targetAuxiliaryObjects) })
+	t.Cleanup(func() {
+		deleteSLOsIfPresent(t, context.WithoutCancel(ctx), movedManifestSLO, manifestSLO)
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, auxiliaryObjects)
+				},
+				Config: newSLOResource(t, sloResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, ctx, manifestSLO),
+				),
+			},
+			{
+				Config: newSLOResource(t, func() sloResourceTemplateModel {
+					m := sloResource
+					m.Project = newProjectName
+					m.Service = newServiceName
+					m.AlertPolicies = nil
+					return m
+				}()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "project", newProjectName),
+					resource.TestCheckResourceAttr("nobl9_slo.test", "service", newServiceName),
+					resource.TestCheckNoResourceAttr("nobl9_slo.test", "alert_policies"),
+					assertResourceWasApplied(t, ctx, movedManifestSLO),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						expectChangesInResourcePlan(planDiff{
+							Modified: []string{"alert_policies", "project", "service"},
+						}),
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
 		},
 	})
 }
@@ -1877,6 +1977,67 @@ func TestRenderSLOResourceTemplate_compositeV1Example(t *testing.T) {
 
 	assertHCL(t, actual)
 	assert.Equal(t, readExpectedConfig(t, "slo-composite-v1-config.tf"), actual)
+}
+
+func Test_sloMovePartialSuccessWarningDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		detachAlertPolicies bool
+		expected            string
+	}{
+		"moved without detaching alert policies": {
+			expected: "SLO definition update failed, but the SLO was moved to a new project." +
+				"\nTerraform state may be stale. Refresh and re-plan before resolving the issues" +
+				" and retrying the update operation. Bear in mind that the SLO will remain in the new project.",
+		},
+		"moved and detached alert policies": {
+			detachAlertPolicies: true,
+			expected: "SLO definition update failed, but the SLO was moved to a new project." +
+				" Its Alert Policies were also detached." +
+				"\nTerraform state may be stale. Refresh and re-plan before resolving the issues" +
+				" and retrying the update operation. Bear in mind that the SLO will remain in the new project.",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, sloMovePartialSuccessWarningDetail(test.detachAlertPolicies))
+		})
+	}
+}
+
+func deleteSLOsIfPresent(t *testing.T, ctx context.Context, slos ...v1alphaSLO.SLO) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	for _, slo := range slos {
+		objects, err := getObjectsFromTheNobl9API(t, ctx, slo)
+		if err != nil {
+			t.Errorf(
+				"failed to locate SLO %q in project %q during cleanup: %v",
+				slo.GetName(),
+				slo.GetProject(),
+				err,
+			)
+			continue
+		}
+		if len(objects) == 0 {
+			continue
+		}
+		if err := testSDKClient.client.Objects().V1().
+			DeleteByName(ctx, manifest.KindSLO, slo.GetProject(), slo.GetName()); err != nil {
+			t.Errorf(
+				"failed to delete SLO %q from project %q during cleanup: %v",
+				slo.GetName(),
+				slo.GetProject(),
+				err,
+			)
+		}
+	}
 }
 
 type sloResourceTemplateModel struct {


### PR DESCRIPTION
## Motivation

Moving an SLO to another Project and Service while removing its Alert Policies in the same Terraform update failed. The framework provider sent the move request without the API's detach flag, so the API rejected an otherwise valid transition.

## Summary

- Requested Alert Policy detachment when an update moved an SLO and changed `alert_policies` from non-empty to empty.
- Preserved the existing validation that rejected moving an SLO while retaining assigned Alert Policies.
- Reported partial-success diagnostics when the remote move succeeded but state reconciliation failed.
- Added acceptance coverage for moving and detaching in one update.

## Testing

The reproduction assumes that the referenced source and target Projects and Services, Prometheus Direct, and source-Project Alert Policy already exist. Apply this configuration:

```hcl
resource "nobl9_slo" "test" {
  name             = "example-slo"
  project          = "source-project"
  service          = "source-service"
  budgeting_method = "Occurrences"
  alert_policies   = ["example-alert-policy"]

  indicator {
    name    = "example-direct"
    project = "source-project"
    kind    = "Direct"
  }

  objective {
    display_name = "availability"
    name         = "availability"
    op           = "lt"
    target       = 0.99
    value        = 1

    raw_metric {
      query {
        prometheus {
          promql = "up"
        }
      }
    }
  }

  time_window {
    count      = 1
    unit       = "Hour"
    is_rolling = true
  }
}
```

Then change these attributes and apply again:

```hcl
project        = "target-project"
service        = "target-service"
alert_policies = []
```

The pre-fix acceptance reproduction returned the following diagnostic. Generated fixture names are retained; only the private API endpoint and ephemeral trace ID are explicitly redacted:

```text
Error: Failed to move terraform-e2e-4-1785770570562374692 SLO from terraform-e2e-1-1785770570562374692 to terraform-e2e-5-1785770570562374692 Project

  with nobl9_slo.test,
  on terraform_plugin_test.tf line 14, in resource "nobl9_slo" "test":
  14:   project = "terraform-e2e-5-1785770570562374692"

Bad Request: {"error":"cannot move terraform-e2e-4-1785770570562374692 SLO
while it has assigned Alert Policies, detach them manually or set
'detachAlertPolicies' parameter to 'true' in the request
body","message":"cannot move terraform-e2e-4-1785770570562374692 SLO while it
has assigned Alert Policies, detach them manually or set
'detachAlertPolicies' parameter to 'true' in the request
body","statusCode":400} (code: 400, endpoint: POST
[REDACTED: private API endpoint], traceId:
[REDACTED: ephemeral trace ID])
```

The corrected acceptance test first created an SLO with an assigned Alert Policy, then moved it to another Project and Service while explicitly rendering `alert_policies = []`. It verified that all three attributes changed in one update, Terraform state contained zero Alert Policies, and the remote SLO was moved without assigned Alert Policies. Removing the detach flag reproduced the diagnostic above; restoring the change allowed the same scenario to complete.

## Release Notes

Enabled SLO resources to move between Projects and Services while detaching all Alert Policies in the same Terraform update.
