### PR TITLE
fix: restore framework resource IDs

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -49,6 +49,10 @@ resource "nobl9_project" "this" {
 - `display_name` (String) User-friendly display name of the resource.
 - `label` (Block List) [Labels](https://docs.nobl9.com/features/labels/) containing a single key and a list of values. (see [below for nested schema](#nestedblock--label))
 
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
 <a id="nestedblock--label"></a>
 ### Nested Schema for `label`
 

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -57,6 +57,10 @@ resource "nobl9_service" "this" {
 - `responsible_users` (Attributes List) List of users responsible for the service. (see [below for nested schema](#nestedatt--responsible_users))
 - `review_cycle` (Attributes) Configuration for service review cycle. (see [below for nested schema](#nestedatt--review_cycle))
 
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
 <a id="nestedblock--label"></a>
 ### Nested Schema for `label`
 

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -220,6 +220,10 @@ resource "nobl9_slo" "composite_slo" {
 - `tier` (String) Internal field, do not use.
 - `time_window` (Block List) Time window configuration for the SLO. (see [below for nested schema](#nestedblock--time_window))
 
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
 <a id="nestedblock--anomaly_config"></a>
 ### Nested Schema for `anomaly_config`
 

--- a/internal/frameworkprovider/metadata_schema.go
+++ b/internal/frameworkprovider/metadata_schema.go
@@ -23,6 +23,16 @@ func metadataNameAttr() schema.StringAttribute {
 	}
 }
 
+func resourceIDAttr() schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed:    true,
+		Description: "The ID of this resource.",
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
 func metadataDisplayNameAttr() schema.StringAttribute {
 	return schema.StringAttribute{
 		Optional:    true,

--- a/internal/frameworkprovider/project_resource.go
+++ b/internal/frameworkprovider/project_resource.go
@@ -41,6 +41,7 @@ func (s *ProjectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		MarkdownDescription: description,
 		Description:         description,
 		Attributes: map[string]schema.Attribute{
+			"id": resourceIDAttr(),
 			"name": func() schema.StringAttribute {
 				attr := metadataNameAttr()
 				return addProjectResourceNameChangeWarning(attr)

--- a/internal/frameworkprovider/project_resource_model.go
+++ b/internal/frameworkprovider/project_resource_model.go
@@ -7,6 +7,7 @@ import (
 
 // ProjectResourceModel describes the [ProjectResource] data model.
 type ProjectResourceModel struct {
+	ID          types.String      `tfsdk:"id"`
 	Name        string            `tfsdk:"name"`
 	DisplayName types.String      `tfsdk:"display_name"`
 	Description types.String      `tfsdk:"description"`
@@ -16,6 +17,7 @@ type ProjectResourceModel struct {
 
 func newProjectResourceConfigFromManifest(project v1alphaProject.Project) *ProjectResourceModel {
 	return &ProjectResourceModel{
+		ID:          types.StringValue(project.Metadata.Name),
 		Name:        project.Metadata.Name,
 		DisplayName: stringValue(project.Metadata.DisplayName),
 		Description: stringValue(project.Spec.Description),

--- a/internal/frameworkprovider/project_resource_test.go
+++ b/internal/frameworkprovider/project_resource_test.go
@@ -37,6 +37,7 @@ func TestAccProjectResource(t *testing.T) {
 			{
 				Config: newProjectResource(t, projectResource),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_project.test", "id", projectResource.Name),
 					assertResourceWasApplied(t, ctx, manifestProject),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -69,6 +70,7 @@ func TestAccProjectResource(t *testing.T) {
 					if !assert.Len(t, states, 1) {
 						return errors.New("expected exactly one state")
 					}
+					assert.Equal(t, projectResource.Name, states[0].Attributes["id"])
 					assert.Equal(t, projectResource.Name, states[0].Attributes["name"])
 					return nil
 				},
@@ -107,6 +109,7 @@ func TestAccProjectResource(t *testing.T) {
 					return m
 				}()),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_project.test", "id", projectNameRecreatedByNameChange),
 					resource.TestCheckResourceAttr("nobl9_project.test", "name", projectNameRecreatedByNameChange),
 					assertResourceWasApplied(t, ctx, func() v1alphaProject.Project {
 						project := manifestProject
@@ -116,7 +119,10 @@ func TestAccProjectResource(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						expectChangesInResourcePlan(planDiff{Modified: []string{"name", "display_name"}}),
+						expectChangesInResourcePlan(planDiff{
+							Modified: []string{"name", "display_name"},
+							Removed:  []string{"id"},
+						}),
 						plancheck.ExpectNonEmptyPlan(),
 						plancheck.ExpectResourceAction("nobl9_project.test", plancheck.ResourceActionReplace),
 					},

--- a/internal/frameworkprovider/service_resource.go
+++ b/internal/frameworkprovider/service_resource.go
@@ -48,6 +48,7 @@ var serviceResourceSchema = func() schema.Schema {
 		MarkdownDescription: description,
 		Description:         description,
 		Attributes: map[string]schema.Attribute{
+			"id": resourceIDAttr(),
 			"name": func() schema.StringAttribute {
 				attr := metadataNameAttr()
 				return addServiceResourceNameChangeWarning(attr)

--- a/internal/frameworkprovider/service_resource_model.go
+++ b/internal/frameworkprovider/service_resource_model.go
@@ -7,6 +7,7 @@ import (
 
 // ServiceResourceModel describes the [ServiceResource] data model.
 type ServiceResourceModel struct {
+	ID               types.String           `tfsdk:"id"`
 	Name             string                 `tfsdk:"name"`
 	DisplayName      types.String           `tfsdk:"display_name"`
 	Project          string                 `tfsdk:"project"`
@@ -53,6 +54,7 @@ func (r ReviewCycleModel) ToManifest() *v1alphaService.ReviewCycle {
 
 func newServiceResourceConfigFromManifest(svc v1alphaService.Service) *ServiceResourceModel {
 	return &ServiceResourceModel{
+		ID:               types.StringValue(svc.Metadata.Name),
 		Name:             svc.Metadata.Name,
 		DisplayName:      stringValue(svc.Metadata.DisplayName),
 		Project:          svc.Metadata.Project,

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -46,6 +46,7 @@ func TestAccServiceResource(t *testing.T) {
 				},
 				Config: newServiceResource(t, serviceResource),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_service.test", "id", serviceResource.Name),
 					assertResourceWasApplied(t, ctx, serviceResource.ToManifest()),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -85,6 +86,7 @@ func TestAccServiceResource(t *testing.T) {
 					if !assert.Len(t, states, 1) {
 						return errors.New("expected exactly one state")
 					}
+					assert.Equal(t, serviceResource.Name, states[0].Attributes["id"])
 					assert.Equal(t, serviceResource.Name, states[0].Attributes["name"])
 					assert.Equal(t, serviceResource.Project, states[0].Attributes["project"])
 					return nil
@@ -125,6 +127,7 @@ func TestAccServiceResource(t *testing.T) {
 					return m
 				}()),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_service.test", "id", serviceNameRecreatedByNameChange),
 					resource.TestCheckResourceAttr("nobl9_service.test", "name", serviceNameRecreatedByNameChange),
 					assertResourceWasApplied(t, ctx, func() v1alphaService.Service {
 						svc := serviceResource.ToManifest()
@@ -152,6 +155,7 @@ func TestAccServiceResource(t *testing.T) {
 					return m
 				}()),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_service.test", "id", serviceNameRecreatedByNameChange),
 					resource.TestCheckResourceAttr("nobl9_service.test", "project", recreatedProjectName),
 					assertResourceWasApplied(t, ctx, func() v1alphaService.Service {
 						svc := serviceResource.ToManifest()
@@ -164,6 +168,7 @@ func TestAccServiceResource(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{
 						expectChangesInResourcePlan(planDiff{
 							Modified: []string{"project"},
+							Removed:  []string{"id"},
 						}),
 						plancheck.ExpectNonEmptyPlan(),
 						plancheck.ExpectResourceAction("nobl9_service.test", plancheck.ResourceActionReplace),

--- a/internal/frameworkprovider/slo_resource_model.go
+++ b/internal/frameworkprovider/slo_resource_model.go
@@ -8,6 +8,7 @@ import (
 
 // SLOResourceModel describes the [SLOResource] data model.
 type SLOResourceModel struct {
+	ID                         types.String         `tfsdk:"id"`
 	Name                       string               `tfsdk:"name"`
 	DisplayName                types.String         `tfsdk:"display_name"`
 	Project                    string               `tfsdk:"project"`
@@ -385,6 +386,7 @@ type Dash0Model struct {
 // It's handled separately in the Create operation.
 func newSLOResourceConfigFromManifest(slo v1alphaSLO.SLO) *SLOResourceModel {
 	model := &SLOResourceModel{
+		ID:              types.StringValue(slo.Metadata.Name),
 		Name:            slo.Metadata.Name,
 		DisplayName:     stringValue(slo.Metadata.DisplayName),
 		Project:         slo.Metadata.Project,

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -27,6 +27,7 @@ var sloResourceSchema = func() schema.Schema {
 		MarkdownDescription: description,
 		Description:         description,
 		Attributes: map[string]schema.Attribute{
+			"id":           resourceIDAttr(),
 			"name":         metadataNameAttr(),
 			"display_name": metadataDisplayNameAttr(),
 			"project": func() schema.Attribute {

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -78,6 +78,7 @@ func TestAccSLOResource(t *testing.T) {
 				},
 				Config: sloConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "id", sloResource.Name),
 					assertResourceWasApplied(t, ctx, manifestSLO),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -118,6 +119,7 @@ func TestAccSLOResource(t *testing.T) {
 					if !assert.Len(t, states, 1) {
 						return errors.New("expected exactly one state")
 					}
+					assert.Equal(t, sloResource.Name, states[0].Attributes["id"])
 					assert.Equal(t, sloResource.Name, states[0].Attributes["name"])
 					assert.Equal(t, sloResource.Project, states[0].Attributes["project"])
 					return nil
@@ -159,6 +161,7 @@ func TestAccSLOResource(t *testing.T) {
 					return m
 				}()),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_slo.test", "id", sloNameRecreatedByNameChange),
 					resource.TestCheckResourceAttr("nobl9_slo.test", "name", sloNameRecreatedByNameChange),
 					assertResourceWasApplied(t, ctx, func() v1alphaSLO.SLO {
 						slo := manifestSLO
@@ -168,7 +171,10 @@ func TestAccSLOResource(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						expectChangesInResourcePlan(planDiff{Modified: []string{"name", "display_name"}}),
+						expectChangesInResourcePlan(planDiff{
+							Modified: []string{"name", "display_name"},
+							Removed:  []string{"id"},
+						}),
 						plancheck.ExpectNonEmptyPlan(),
 						plancheck.ExpectResourceAction("nobl9_slo.test", plancheck.ResourceActionReplace),
 					},


### PR DESCRIPTION
## Motivation

The migrated Project, Service, and SLO resources dropped the computed `id` attribute exposed by their legacy SDK implementations. Existing configurations that referenced `resource.id` therefore failed after upgrading to the framework resources.

## Summary

- Restored the computed `id` attribute for Project, Service, and SLO resources.
- Populated `id` from the Nobl9 resource name during create, read, and import.
- Preserved the prior ID while a plan was unknown and updated it after name replacement.
- Regenerated the affected resource documentation.
- Added acceptance coverage for creation, import, and replacement.

## Testing

Minimal configuration:

```hcl
resource "nobl9_project" "this" {
  name = "example-project"
}

output "project_id" {
  value = nobl9_project.this.id
}
```

Before this change, Terraform returned:

```text
Error: Unsupported attribute

  on main.tf line 6, in output "project_id":
   6:   value = nobl9_project.this.id

This object has no argument, nested block, or exported attribute named "id".
```

The updated provider returned `example-project`. Acceptance coverage verified equivalent behavior for Project, Service, and SLO resources during creation, import, and name replacement.

## Release Notes

Restored the resource name through the computed `id` attribute on Project, Service, and SLO resources.
