### PR TITLE
fix: defer unknown objective value validation

### DIFF
--- a/internal/frameworkprovider/plan_modifiers.go
+++ b/internal/frameworkprovider/plan_modifiers.go
@@ -31,16 +31,19 @@ func (s sloObjectiveValuePlanModifier) PlanModifyFloat64(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	nullOrUnknown := isNullOrUnknown(req.PlanValue)
+	if req.PlanValue.IsUnknown() {
+		return
+	}
+	valueIsNull := req.PlanValue.IsNull()
 	compositeObjectives := hasCompositeObjectives(objectives)
 	switch {
-	case !nullOrUnknown && compositeObjectives:
+	case !valueIsNull && compositeObjectives:
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"objective value cannot be set when defining composite SLOs",
 			"",
 		)
-	case nullOrUnknown && !compositeObjectives:
+	case valueIsNull && !compositeObjectives:
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"objective value must be set for ratio and threshold objectives",

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -1385,6 +1385,62 @@ func TestAccSLOResource_objectiveValueErrors(t *testing.T) {
 	}
 }
 
+func TestAccSLOResource_unknownObjectiveValue(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	manifestService := getExampleServiceResource(t).ToManifest()
+	manifestService.Metadata.Project = manifestProject.GetName()
+	auxiliaryObjects := []manifest.Object{manifestProject, manifestService}
+
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "this",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = manifestProject.GetName()
+	sloResource.Service = manifestService.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+
+	manifestSLO := sloResource.ToManifest()
+	sloConfig := newSLOResource(t, sloResource)
+	sloConfig = strings.Replace(
+		sloConfig,
+		"\n    value = 1\n",
+		"\n    value = terraform_data.objective_value.output\n",
+		1,
+	)
+	require.Contains(t, sloConfig, "value = terraform_data.objective_value.output")
+	sloConfig = `
+resource "terraform_data" "objective_value" {
+  input = 1
+}
+` + sloConfig
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, auxiliaryObjects)
+					t.Cleanup(func() { e2etestutils.V1Delete(t, auxiliaryObjects) })
+				},
+				Config: sloConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					assertResourceWasApplied(t, t.Context(), manifestSLO),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSLOResource_sumologicValidationErrors(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)


### PR DESCRIPTION
## Motivation

The framework SLO resource treated an unknown `objective.value` as if it were omitted. Valid configurations whose value is produced during apply therefore failed during planning with `objective value must be set for ratio and threshold objectives`.

## Summary

- Deferred objective-value validation while the planned value was unknown.
- Continued rejecting null values for ratio and threshold objectives.
- Continued rejecting known values for composite objectives.
- Added acceptance coverage with a genuinely apply-time value.

## Testing

The reproduction requires an existing Service and AppDynamics Direct. Set `slo_project` and `service_name` to an existing Service, and set `direct_name` and `direct_project` to an existing AppDynamics Direct:

```hcl
variable "slo_project" {
  type = string
}

variable "service_name" {
  type = string
}

variable "direct_name" {
  type = string
}

variable "direct_project" {
  type = string
}

resource "terraform_data" "objective_value" {
  input = 1
}

resource "nobl9_slo" "this" {
  name             = "example-slo"
  project          = var.slo_project
  service          = var.service_name
  budgeting_method = "Occurrences"

  indicator {
    name    = var.direct_name
    project = var.direct_project
    kind    = "Direct"
  }

  objective {
    value        = terraform_data.objective_value.output
    display_name = "availability"
    name         = "objective-1"
    op           = "lt"
    target       = 0.99

    raw_metric {
      query {
        appdynamics {
          application_name = "my_app"
          metric_path      = "End User Experience|App|End User Response Time 95th percentile (ms)"
        }
      }
    }
  }

  time_window {
    count      = 1
    unit       = "Hour"
    is_rolling = true
  }
}
```

Before this change, the initial plan returned:

```text
Error: objective value must be set for ratio and threshold objectives

  with nobl9_slo.this,
  on main.tf line 34, in resource "nobl9_slo" "this":
  34:     value        = terraform_data.objective_value.output
```

`TestAccSLOResource_unknownObjectiveValue` provisioned a Project and Service together with a static AppDynamics Direct, supplied `objective.value` from a `terraform_data` resource, and verified that the SLO was applied after the value resolved.

## Release Notes

Allowed SLO objective values to be supplied by expressions that remained unknown until apply.
