### PR TITLE
fix: restore framework service status

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -57,6 +57,10 @@ resource "nobl9_service" "this" {
 - `responsible_users` (Attributes List) List of users responsible for the service. (see [below for nested schema](#nestedatt--responsible_users))
 - `review_cycle` (Attributes) Configuration for service review cycle. (see [below for nested schema](#nestedatt--review_cycle))
 
+### Read-Only
+
+- `status` (Object) Status of created service. (see [below for nested schema](#nestedatt--status))
+
 <a id="nestedblock--label"></a>
 ### Nested Schema for `label`
 
@@ -82,6 +86,14 @@ Required:
 - `rrule` (String) Recurring rule in RFC 5545 RRULE format defining when a review should occur.
 - `start_time` (String) Start time (inclusive) for the first occurrence defined by the rrule. Specified as an ISO 8601 date-time string without a time zone designator (e.g. 2024-01-02T15:04:05). The time zone is specified separately in the `time_zone` attribute.
 - `time_zone` (String) Time zone identifier (IANA) used to interpret `start_time` and `rrule` times (e.g. Europe/Warsaw).
+
+
+<a id="nestedatt--status"></a>
+### Nested Schema for `status`
+
+Read-Only:
+
+- `slo_count` (Number)
 
 ## Useful Links
 

--- a/internal/frameworkprovider/service_resource.go
+++ b/internal/frameworkprovider/service_resource.go
@@ -5,13 +5,16 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/nobl9/nobl9-go/manifest"
 )
 
@@ -61,12 +64,24 @@ var serviceResourceSchema = func() schema.Schema {
 			"annotations":       metadataAnnotationsAttr(),
 			"responsible_users": serviceResponsibleUserAttribute(),
 			"review_cycle":      serviceReviewCycleAttribute(),
+			"status": schema.ObjectAttribute{
+				Computed:       true,
+				Description:    "Status of created service.",
+				AttributeTypes: serviceStatusAttributeTypes,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"label": metadataLabelsBlock(),
 		},
 	}
 }()
+
+var serviceStatusAttributeTypes = map[string]attr.Type{
+	"slo_count": types.Int64Type,
+}
 
 func serviceReviewCycleAttribute() schema.Attribute {
 	return schema.SingleNestedAttribute{

--- a/internal/frameworkprovider/service_resource_model.go
+++ b/internal/frameworkprovider/service_resource_model.go
@@ -1,6 +1,7 @@
 package frameworkprovider
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v1alphaService "github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 )
@@ -15,6 +16,7 @@ type ServiceResourceModel struct {
 	Labels           Labels                 `tfsdk:"label"`
 	ResponsibleUsers []ResponsibleUserModel `tfsdk:"responsible_users"`
 	ReviewCycle      *ReviewCycleModel      `tfsdk:"review_cycle"`
+	Status           types.Object           `tfsdk:"status"`
 }
 
 // ResponsibleUserModel represents [v1alphaService.ResponsibleUser].
@@ -52,6 +54,13 @@ func (r ReviewCycleModel) ToManifest() *v1alphaService.ReviewCycle {
 }
 
 func newServiceResourceConfigFromManifest(svc v1alphaService.Service) *ServiceResourceModel {
+	status := types.ObjectNull(serviceStatusAttributeTypes)
+	if svc.Status != nil {
+		status = types.ObjectValueMust(serviceStatusAttributeTypes, map[string]attr.Value{
+			"slo_count": types.Int64Value(int64(svc.Status.SloCount)),
+		})
+	}
+
 	return &ServiceResourceModel{
 		Name:             svc.Metadata.Name,
 		DisplayName:      stringValue(svc.Metadata.DisplayName),
@@ -61,6 +70,7 @@ func newServiceResourceConfigFromManifest(svc v1alphaService.Service) *ServiceRe
 		Labels:           newLabelsFromManifest(svc.Metadata.Labels),
 		ResponsibleUsers: newResponsibleUsersFromManifest(svc.Spec.ResponsibleUsers),
 		ReviewCycle:      newReviewCycleFromManifest(svc.Spec.ReviewCycle),
+		Status:           status,
 	}
 }
 

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -192,6 +192,8 @@ func TestAccServiceResource_status(t *testing.T) {
 	serviceResource.Project = manifestProject.GetName()
 	serviceResource.ResponsibleUsers = nil
 	serviceResource.ReviewCycle = nil
+	updatedServiceResource := serviceResource
+	updatedServiceResource.Description = types.StringValue("Updated service description")
 
 	sloResource := sloResourceTemplateModel{
 		ResourceName:     "test",
@@ -235,6 +237,25 @@ func TestAccServiceResource_status(t *testing.T) {
 				},
 				Config: newServiceResource(t, serviceResource),
 				Check:  resource.TestCheckResourceAttr("nobl9_service.test", "status.slo_count", "1"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: newServiceResource(t, updatedServiceResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("nobl9_service.test", "description", "Updated service description"),
+					resource.TestCheckResourceAttr("nobl9_service.test", "status.slo_count", "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						expectChangesInResourcePlan(planDiff{Modified: []string{"description"}}),
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("nobl9_service.test", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})

--- a/internal/frameworkprovider/service_resource_test.go
+++ b/internal/frameworkprovider/service_resource_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/nobl9/nobl9-go/manifest"
+	"github.com/nobl9/nobl9-go/manifest/v1alpha"
 	v1alphaService "github.com/nobl9/nobl9-go/manifest/v1alpha/service"
 	"github.com/nobl9/nobl9-go/tests/e2etestutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccServiceResource(t *testing.T) {
@@ -163,6 +165,7 @@ func TestAccServiceResource(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						expectChangesInResourcePlan(planDiff{
+							Removed:  []string{"status"},
 							Modified: []string{"project"},
 						}),
 						plancheck.ExpectNonEmptyPlan(),
@@ -171,6 +174,68 @@ func TestAccServiceResource(t *testing.T) {
 				},
 			},
 			// Delete automatically occurs in TestCase, no need to clean up.
+		},
+	})
+}
+
+func TestAccServiceResource_status(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	serviceResource := serviceResourceTemplateModel{
+		ResourceName:         "test",
+		ServiceResourceModel: getExampleServiceResource(t),
+	}
+	serviceResource.Project = manifestProject.GetName()
+	serviceResource.ResponsibleUsers = nil
+	serviceResource.ReviewCycle = nil
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = manifestProject.GetName()
+	sloResource.Service = serviceResource.Name
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+	manifestSLO := sloResource.ToManifest()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, []manifest.Object{manifestProject})
+					t.Cleanup(func() { e2etestutils.V1Delete(t, []manifest.Object{manifestProject}) })
+				},
+				Config: newServiceResource(t, serviceResource),
+				Check:  resource.TestCheckResourceAttr("nobl9_service.test", "status.slo_count", "0"),
+			},
+			{
+				PreConfig: func() {
+					e2etestutils.V1Apply(t, []manifest.Object{manifestSLO})
+					t.Cleanup(func() {
+						objects, err := getObjectsFromTheNobl9API(
+							t,
+							context.WithoutCancel(t.Context()),
+							manifestSLO,
+						)
+						require.NoError(t, err)
+						if len(objects) == 1 {
+							e2etestutils.V1Delete(t, []manifest.Object{manifestSLO})
+						}
+					})
+				},
+				Config: newServiceResource(t, serviceResource),
+				Check:  resource.TestCheckResourceAttr("nobl9_service.test", "status.slo_count", "1"),
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Motivation

The framework Service resource previously exposed the stable SLO count through `status.slo_count`, but the entire status attribute was later removed while unstable status fields were being eliminated. Configurations that used the released SLO-count attribute then failed because the resource no longer exposed the top-level `status` attribute.

## Summary

- Restored the computed `status.slo_count` attribute.
- Populated the count during create, read, and import.
- Preserved known status for ordinary plans while leaving replacement status unknown.
- Excluded unstable review-cycle status fields.
- Regenerated the Service resource documentation.
- Added acceptance coverage for refresh and update behavior.

## Testing

Minimal configuration:

```hcl
resource "nobl9_project" "this" {
  name = "example-project"
}

resource "nobl9_service" "this" {
  name    = "example-service"
  project = nobl9_project.this.name
}

output "service_slo_count" {
  value = nobl9_service.this.status.slo_count
}
```

Before this change, Terraform returned:

```text
Error: Unsupported attribute

  on main.tf line 11, in output "service_slo_count":
  11:   value = nobl9_service.this.status.slo_count

This object has no argument, nested block, or exported attribute named
"status".
```

The acceptance test verified `0` for a new Service and `1` after external SLO creation and state refresh. It then updated the Service description, verified that only the description changed, and confirmed that `status.slo_count` remained `1`.

## Release Notes

Restored the current SLO count through the computed Service `status.slo_count` attribute.
