### PR TITLE
fix: require anomaly alert methods

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -233,7 +233,7 @@ Optional:
 Optional:
 
 - `alert_after` (String) Specifies the duration to wait after receiving no data before triggering an alert. The value must be a valid Go duration string, such as "1h" for one hour. If not specified, the system defaults to "15m" (15 minutes).
-- `alert_method` (Block List) Alert methods attached to Anomaly Config. (see [below for nested schema](#nestedblock--anomaly_config--no_data--alert_method))
+- `alert_method` (Block List) Required alert methods attached to Anomaly Config. At least 1 and at most 5 alert methods can be configured. (see [below for nested schema](#nestedblock--anomaly_config--no_data--alert_method))
 - `treat_zero_as_no_data` (Boolean) Specifies whether zero values should be treated as no data.
 
 <a id="nestedblock--anomaly_config--no_data--alert_method"></a>

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -305,8 +305,12 @@ func anomalyConfigBlock() schema.ListNestedBlock {
 					NestedObject: schema.NestedBlockObject{
 						Blocks: map[string]schema.Block{
 							"alert_method": schema.ListNestedBlock{
-								Description: "Alert methods attached to Anomaly Config.",
-								Validators:  []validator.List{listvalidator.SizeBetween(1, 5)},
+								Description: "Required alert methods attached to Anomaly Config. " +
+									"At least 1 and at most 5 alert methods can be configured.",
+								Validators: []validator.List{
+									listvalidator.IsRequired(),
+									listvalidator.SizeBetween(1, 5),
+								},
 								NestedObject: schema.NestedBlockObject{
 									Attributes: map[string]schema.Attribute{
 										"name": schema.StringAttribute{

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -235,6 +235,33 @@ func TestAccSLOResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_anomalyAlertMethodRequired(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	model := getExampleSLOResource(t)
+	model.Name = e2etestutils.GenerateName()
+	model.AnomalyConfig = []AnomalyConfigModel{{
+		NoData: []AnomalyConfigNoDataModel{{
+			AlertAfter: types.StringValue("15m"),
+		}},
+	}}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: newSLOResource(t, sloResourceTemplateModel{
+					ResourceName:     "test",
+					SLOResourceModel: model,
+				}),
+				ExpectError: regexp.MustCompile(`(?s)Error: Invalid Block.*marked it as required`),
+				PlanOnly:    true,
+			},
+		},
+	})
+}
+
 func TestAccSLOResource_labelValidationErrors(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)


### PR DESCRIPTION
## Motivation

The framework SLO schema allowed `anomaly_config.no_data` without an `alert_method` block even though the API requires at least one alert method. This delayed a deterministic configuration error until API validation.

## Summary

- Required between one and five `alert_method` blocks for anomaly no-data configuration.
- Documented the required cardinality in the generated SLO resource reference.
- Added plan-only acceptance coverage for the framework diagnostic.

## Testing

The API-side reproduction requires an existing Service and AppDynamics Agent data source in the same Project. Set `service_name` and `indicator_name` to those existing object names:

```hcl
variable "service_name" {
  type = string
}

variable "indicator_name" {
  type = string
}

resource "nobl9_slo" "repro" {
  name             = "example-slo"
  project          = "default"
  service          = var.service_name
  budgeting_method = "Occurrences"

  indicator {
    name    = var.indicator_name
    project = "default"
    kind    = "Agent"
  }

  objective {
    name   = "tf-objective-1"
    op     = "lt"
    target = 0.7
    value  = 1

    raw_metric {
      query {
        appdynamics {
          application_name = "example-application"
          metric_path      = "example-metric"
        }
      }
    }
  }

  time_window {
    count      = 10
    unit       = "Minute"
    is_rolling = true
  }

  anomaly_config {
    no_data {
      alert_after = "15m"
    }
  }
}
```

The pre-fix acceptance reproduction returned the following diagnostic. The generated fixture name is retained; only the private API endpoint and ephemeral trace ID are explicitly redacted:

```text
Error: Dry-run apply failed for n9/v1alpha SLO

  with nobl9_slo.test,
  on terraform_plugin_test.tf line 11, in resource "nobl9_slo" "test":
  11: resource "nobl9_slo" "test" {

Bad Request: Validation for SLO 'terraform-e2e-1-1785771388694920805' in
project 'default' has failed for the following fields:
  - 'spec.anomalyConfig.noData.alertMethods' with value '[]':
    - length must be greater than or equal to 1
Manifest source: PUT :///api/apply (code: 400, endpoint: PUT
[REDACTED: private API endpoint], traceId:
[REDACTED: ephemeral trace ID])
```

With this change, the same acceptance scenario returns the framework diagnostic before API dry-run:

```text
Error: Invalid Block

  with nobl9_slo.test,
  on terraform_plugin_test.tf line 82, in resource "nobl9_slo" "test":
  82:     no_data {

Block anomaly_config[0].no_data[0].alert_method must have a configuration
value as the provider has marked it as required
```

`TestAccSLOResource_anomalyAlertMethodRequired` covers the same missing `alert_method` block and asserts the local framework diagnostic.

## Release Notes

Updated Terraform planning to require between one and five alert methods for SLO anomaly no-data configuration.
