### PR TITLE
fix: restore SLO time-window period

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -2509,6 +2509,10 @@ Optional:
 - `calendar` (Block List) Calendar configuration for the time window. (see [below for nested schema](#nestedblock--time_window--calendar))
 - `is_rolling` (Boolean) Is the window moving or not.
 
+Read-Only:
+
+- `period` (Map of String) Period between start time and added count.
+
 <a id="nestedblock--time_window--calendar"></a>
 ### Nested Schema for `time_window.calendar`
 

--- a/internal/frameworkprovider/slo_resource_model.go
+++ b/internal/frameworkprovider/slo_resource_model.go
@@ -1,6 +1,7 @@
 package frameworkprovider
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/nobl9/nobl9-go/manifest"
 	v1alphaSLO "github.com/nobl9/nobl9-go/manifest/v1alpha/slo"
@@ -131,6 +132,7 @@ type CompositeObjectiveSpecModel struct {
 type TimeWindowModel struct {
 	Count     int64           `tfsdk:"count"`
 	IsRolling types.Bool      `tfsdk:"is_rolling"`
+	Period    types.Map       `tfsdk:"period"`
 	Unit      string          `tfsdk:"unit"`
 	Calendar  []CalendarModel `tfsdk:"calendar"`
 }
@@ -437,6 +439,7 @@ func newSLOResourceConfigFromManifest(slo v1alphaSLO.SLO) *SLOResourceModel {
 		twModel := TimeWindowModel{
 			Count:     int64(tw.Count),
 			IsRolling: types.BoolValue(tw.IsRolling),
+			Period:    timeWindowPeriodToMap(tw.Period),
 			Unit:      tw.Unit,
 		}
 		if tw.Calendar != nil {
@@ -476,6 +479,16 @@ func newSLOResourceConfigFromManifest(slo v1alphaSLO.SLO) *SLOResourceModel {
 	}
 	model.Composite = compositeV1ToModel(slo.Spec.Composite)
 	return model
+}
+
+func timeWindowPeriodToMap(period *v1alphaSLO.Period) types.Map {
+	if period == nil {
+		return types.MapNull(types.StringType)
+	}
+	return types.MapValueMust(types.StringType, map[string]attr.Value{
+		"begin": types.StringValue(period.Begin),
+		"end":   types.StringValue(period.End),
+	})
 }
 
 func (s SLOResourceModel) ToManifest() v1alphaSLO.SLO {

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -241,6 +241,11 @@ func sloResourceTimeWindowBlock() schema.ListNestedBlock {
 					Default:     booldefault.StaticBool(false),
 					Description: "Is the window moving or not.",
 				},
+				"period": schema.MapAttribute{
+					ElementType: types.StringType,
+					Computed:    true,
+					Description: "Period between start time and added count.",
+				},
 				"unit": schema.StringAttribute{
 					Required:    true,
 					Description: "Unit of time.",

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -179,6 +179,45 @@ func TestAccSLOResource(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_timeWindowPeriod(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+	ctx := t.Context()
+
+	manifestProject := getExampleProjectResource(t).ToManifest()
+	manifestService := getExampleServiceResource(t).ToManifest()
+	manifestService.Metadata.Project = manifestProject.GetName()
+	auxiliaryObjects := []manifest.Object{manifestProject, manifestService}
+
+	manifestDirect := e2etestutils.ProvisionStaticDirect(t, v1alpha.AppDynamics)
+
+	sloResource := sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: getExampleSLOResource(t),
+	}
+	sloResource.Name = e2etestutils.GenerateName()
+	sloResource.Project = manifestProject.GetName()
+	sloResource.Service = manifestService.GetName()
+	sloResource.Indicator = []IndicatorModel{{
+		Name:    manifestDirect.GetName(),
+		Project: types.StringValue(manifestDirect.GetProject()),
+		Kind:    types.StringValue(manifestDirect.GetKind().String()),
+	}}
+	manifestSLO := sloResource.ToManifest()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			PreConfig: func() {
+				e2etestutils.V1Apply(t, auxiliaryObjects)
+				t.Cleanup(func() { e2etestutils.V1Delete(t, auxiliaryObjects) })
+			},
+			Config: newSLOResource(t, sloResource),
+			Check:  assertSLOTimeWindowPeriodMatchesAPI(t, ctx, "nobl9_slo.test", manifestSLO),
+		}},
+	})
+}
+
 func TestAccSLOResource_planValidation(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)
@@ -1877,6 +1916,56 @@ func TestRenderSLOResourceTemplate_compositeV1Example(t *testing.T) {
 
 	assertHCL(t, actual)
 	assert.Equal(t, readExpectedConfig(t, "slo-composite-v1-config.tf"), actual)
+}
+
+func assertSLOTimeWindowPeriodMatchesAPI(
+	t *testing.T,
+	ctx context.Context,
+	resourceName string,
+	expected v1alphaSLO.SLO,
+) resource.TestCheckFunc {
+	t.Helper()
+
+	return func(state *terraform.State) error {
+		objects, err := getObjectsFromTheNobl9API(t, ctx, expected)
+		if err != nil {
+			return fmt.Errorf("get SLO time window period from API: %w", err)
+		}
+		if len(objects) != 1 {
+			return fmt.Errorf("expected exactly one API object, got %d", len(objects))
+		}
+		slo, ok := objects[0].(v1alphaSLO.SLO)
+		if !ok {
+			return fmt.Errorf("expected API object to be an SLO, got %T", objects[0])
+		}
+		if len(slo.Spec.TimeWindows) != 1 {
+			return fmt.Errorf("expected exactly one API SLO time window, got %d", len(slo.Spec.TimeWindows))
+		}
+		period := slo.Spec.TimeWindows[0].Period
+		if period == nil {
+			return errors.New("expected API SLO time window period to be set")
+		}
+
+		resourceState, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("terraform resource not found in state: %s", resourceName)
+		}
+		begin, ok := resourceState.Primary.Attributes["time_window.0.period.begin"]
+		if !ok {
+			return errors.New("terraform time_window.0.period.begin attribute not found in state")
+		}
+		if begin != period.Begin {
+			return fmt.Errorf("terraform period begin %q does not match API period begin %q", begin, period.Begin)
+		}
+		end, ok := resourceState.Primary.Attributes["time_window.0.period.end"]
+		if !ok {
+			return errors.New("terraform time_window.0.period.end attribute not found in state")
+		}
+		if end != period.End {
+			return fmt.Errorf("terraform period end %q does not match API period end %q", end, period.End)
+		}
+		return nil
+	}
 }
 
 type sloResourceTemplateModel struct {


### PR DESCRIPTION
## Motivation

The framework migration omitted the computed `time_window.period` map from the SLO resource. Configurations that read the API-calculated `begin` and `end` timestamps therefore failed with an unsupported-attribute error.

## Summary

- Restored the computed `time_window.period` map with `begin` and `end` values.
- Hydrated the map from the SLO returned by the API while preserving a null period.
- Documented the restored read-only field.
- Added acceptance coverage that compared both state values with the API response.

## Testing

The regression was reproduced with this minimal configuration after supplying an existing service and Direct metric source:

```hcl
variable "project" {
  type = string
}

variable "service" {
  type = string
}

variable "indicator_name" {
  type = string
}

variable "indicator_project" {
  type = string
}

resource "nobl9_slo" "repro" {
  name             = "example-slo"
  project          = var.project
  service          = var.service
  budgeting_method = "Occurrences"

  indicator {
    name    = var.indicator_name
    project = var.indicator_project
    kind    = "Direct"
  }

  objective {
    target = 0.99
    value  = 1
    op     = "lt"

    raw_metric {
      query {
        prometheus {
          promql = "up"
        }
      }
    }
  }

  time_window {
    count      = 1
    unit       = "Hour"
    is_rolling = true
  }
}

output "period" {
  value = nobl9_slo.repro.time_window[0].period
}
```

Before this change, the output reference returned:

```text
Error: Unsupported attribute

  on main.tf line 51, in output "period":
  51:   value = nobl9_slo.repro.time_window[0].period

This object has no argument, nested block, or exported attribute named
"period".
```

`TestAccSLOResource_timeWindowPeriod` verified that the restored state contains the API-calculated `begin` and `end` timestamps after apply.

## Release Notes

Restored the API-calculated `time_window.period.begin` and `time_window.period.end` values on SLO resources.
