### PR TITLE
fix: require Instana application grouping

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -631,7 +631,7 @@ Required:
 
 Optional:
 
-- `group_by` (Block List) Group by method (see [below for nested schema](#nestedblock--objective--count_metrics--bad--instana--application--group_by))
+- `group_by` (Block List) Group by method. Exactly one block is required. (see [below for nested schema](#nestedblock--objective--count_metrics--bad--instana--application--group_by))
 - `include_internal` (Boolean) Include internal
 - `include_synthetic` (Boolean) Include synthetic
 
@@ -1053,7 +1053,7 @@ Required:
 
 Optional:
 
-- `group_by` (Block List) Group by method (see [below for nested schema](#nestedblock--objective--count_metrics--good--instana--application--group_by))
+- `group_by` (Block List) Group by method. Exactly one block is required. (see [below for nested schema](#nestedblock--objective--count_metrics--good--instana--application--group_by))
 - `include_internal` (Boolean) Include internal
 - `include_synthetic` (Boolean) Include synthetic
 
@@ -1475,7 +1475,7 @@ Required:
 
 Optional:
 
-- `group_by` (Block List) Group by method (see [below for nested schema](#nestedblock--objective--count_metrics--good_total--instana--application--group_by))
+- `group_by` (Block List) Group by method. Exactly one block is required. (see [below for nested schema](#nestedblock--objective--count_metrics--good_total--instana--application--group_by))
 - `include_internal` (Boolean) Include internal
 - `include_synthetic` (Boolean) Include synthetic
 
@@ -1897,7 +1897,7 @@ Required:
 
 Optional:
 
-- `group_by` (Block List) Group by method (see [below for nested schema](#nestedblock--objective--count_metrics--total--instana--application--group_by))
+- `group_by` (Block List) Group by method. Exactly one block is required. (see [below for nested schema](#nestedblock--objective--count_metrics--total--instana--application--group_by))
 - `include_internal` (Boolean) Include internal
 - `include_synthetic` (Boolean) Include synthetic
 
@@ -2327,7 +2327,7 @@ Required:
 
 Optional:
 
-- `group_by` (Block List) Group by method (see [below for nested schema](#nestedblock--objective--raw_metric--query--instana--application--group_by))
+- `group_by` (Block List) Group by method. Exactly one block is required. (see [below for nested schema](#nestedblock--objective--raw_metric--query--instana--application--group_by))
 - `include_internal` (Boolean) Include internal
 - `include_synthetic` (Boolean) Include synthetic
 

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -721,8 +721,11 @@ func sloResourceMetricSpecBlocks() map[string]schema.Block {
 							},
 							Blocks: map[string]schema.Block{
 								"group_by": schema.ListNestedBlock{
-									Description: "Group by method",
-									Validators:  []validator.List{listvalidator.SizeAtMost(1)},
+									Description: "Group by method. Exactly one block is required.",
+									Validators: []validator.List{
+										listvalidator.IsRequired(),
+										listvalidator.SizeBetween(1, 1),
+									},
 									NestedObject: schema.NestedBlockObject{
 										Attributes: map[string]schema.Attribute{
 											"tag": schema.StringAttribute{

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -235,6 +235,84 @@ func TestAccSLOResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_instanaApplicationRequiresExactlyOneGroupBy(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	model := getExampleSLOResource(t)
+	model.Name = e2etestutils.GenerateName()
+	model.Objectives[0].RawMetric[0].Query[0] = MetricSpecModel{
+		Instana: []InstanaModel{{
+			MetricType: "application",
+			Application: []InstanaApplicationModel{{
+				MetricID:    "calls",
+				Aggregation: "sum",
+				APIQuery:    "{}",
+			}},
+		}},
+	}
+
+	configWithoutGroupBy := newSLOResource(t, sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: model,
+	})
+	configWithEmptyGroupBy := strings.Replace(
+		configWithoutGroupBy,
+		`api_query = "{}"`,
+		`api_query = "{}"
+
+            dynamic "group_by" {
+              for_each = []
+              content {
+                tag        = "unused"
+                tag_entity = "NOT_APPLICABLE"
+              }
+            }`,
+		1,
+	)
+	require.NotEqual(t, configWithoutGroupBy, configWithEmptyGroupBy)
+	configWithTwoGroupBy := strings.Replace(
+		configWithoutGroupBy,
+		`api_query = "{}"`,
+		`api_query = "{}"
+
+            group_by {
+              tag        = "first"
+              tag_entity = "NOT_APPLICABLE"
+            }
+
+            group_by {
+              tag        = "second"
+              tag_entity = "NOT_APPLICABLE"
+            }`,
+		1,
+	)
+	require.NotEqual(t, configWithoutGroupBy, configWithTwoGroupBy)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      configWithoutGroupBy,
+				ExpectError: regexp.MustCompile(`(?s)Error: Invalid Block.*marked it as required`),
+				PlanOnly:    true,
+			},
+			{
+				Config:      configWithEmptyGroupBy,
+				ExpectError: regexp.MustCompile(`(?s)Error: Invalid Block.*marked it as required`),
+				PlanOnly:    true,
+			},
+			{
+				Config: configWithTwoGroupBy,
+				ExpectError: regexp.MustCompile(
+					`(?s)Error: Invalid Attribute Value.*list\s+must contain at least 1 elements and at most 1 elements`,
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccSLOResource_labelValidationErrors(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)


### PR DESCRIPTION
## Motivation

The framework SLO schema allowed an Instana application query without a `group_by` block, although the legacy provider and API require exactly one. This delayed deterministic cardinality errors until API validation.

## Summary

- Required exactly one Instana application `group_by` block.
- Documented the exact cardinality in the generated SLO resource reference.
- Added acceptance coverage for omitted, empty, and oversized block collections.

## Testing

The missing-block regression was reproduced with this minimal configuration after supplying an existing service and Instana metric source:

```hcl
variable "project" {
  type = string
}

variable "service" {
  type = string
}

variable "indicator_name" {
  type = string
}

variable "indicator_project" {
  type = string
}

resource "nobl9_slo" "repro" {
  name             = "example-slo"
  project          = var.project
  service          = var.service
  budgeting_method = "Occurrences"

  indicator {
    name    = var.indicator_name
    project = var.indicator_project
    kind    = "Direct"
  }

  objective {
    target = 0.99
    value  = 1
    op     = "lt"

    raw_metric {
      query {
        instana {
          metric_type = "application"

          application {
            metric_id   = "calls"
            aggregation = "sum"
            api_query   = "{}"
          }
        }
      }
    }
  }

  time_window {
    count      = 1
    unit       = "Day"
    is_rolling = true
  }
}
```

Before this change, validation reached the API and returned this stable diagnostic; dynamic transport metadata is omitted:

```text
Error: Dry-run apply failed for n9/v1alpha SLO

  - 'spec.objectives[0].rawMetric.query.instana.application.groupBy':
    - property is required but was empty
```

With this change, planning returns:

```text
Error: Invalid Block

Block objective[0].raw_metric[0].query[0].instana[0].application[0].group_by
must have a configuration value as the provider has marked it as required
```

`TestAccSLOResource_instanaApplicationRequiresExactlyOneGroupBy` covered the missing block and local diagnostic. The same acceptance test covered empty and oversized collections.

## Release Notes

Updated Terraform planning to require exactly one `group_by` block for Instana application metric queries in SLO resources.
