### PR TITLE
fix: enforce deprecated composite cardinality

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -210,7 +210,7 @@ resource "nobl9_slo" "composite_slo" {
 - `annotations` (Map of String) [Metadata annotations](https://docs.nobl9.com/features/labels/#metadata-annotations) attached to the resource.
 - `anomaly_config` (Block List) Configuration for anomaly detection. (see [below for nested schema](#nestedblock--anomaly_config))
 - `attachment` (Block List) URL attachments for the SLO. (see [below for nested schema](#nestedblock--attachment))
-- `composite` (Block List, Deprecated) ("composite" is deprecated, use [composites 2.0 schema](https://registry.terraform.io/providers/nobl9/nobl9/latest/docs/resources/slo#nested-schema-for-objectivecomposite) instead) [Composite SLO documentation](https://docs.nobl9.com/yaml-guide/#slo) (see [below for nested schema](#nestedblock--composite))
+- `composite` (Block List, Deprecated) Optional deprecated composite configuration. At most 1 block can be configured. Use [composites 2.0 schema](https://registry.terraform.io/providers/nobl9/nobl9/latest/docs/resources/slo#nested-schema-for-objectivecomposite) instead. [Composite SLO documentation](https://docs.nobl9.com/yaml-guide/#slo) (see [below for nested schema](#nestedblock--composite))
 - `description` (String) Optional description of the resource. Here, you can add details about who is responsible for the integration (team/owner) or the purpose of creating it.
 - `display_name` (String) User-friendly display name of the resource.
 - `indicator` (Block List) Configuration for the metric source (Agent/Direct). (see [below for nested schema](#nestedblock--indicator))

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -1106,8 +1106,11 @@ func sloResourceCompositeV2ObjectiveBlock() schema.ListNestedBlock {
 
 func sloResourceCompositeV1Block() schema.ListNestedBlock {
 	return schema.ListNestedBlock{
-		Description:        "(\"composite\" is deprecated, use [composites 2.0 schema](https://registry.terraform.io/providers/nobl9/nobl9/latest/docs/resources/slo#nested-schema-for-objectivecomposite) instead) [Composite SLO documentation](https://docs.nobl9.com/yaml-guide/#slo)",
+		Description: "Optional deprecated composite configuration. At most 1 block can be configured. " +
+			"Use [composites 2.0 schema](https://registry.terraform.io/providers/nobl9/nobl9/latest/docs/resources/slo#nested-schema-for-objectivecomposite) instead. " +
+			"[Composite SLO documentation](https://docs.nobl9.com/yaml-guide/#slo)",
 		DeprecationMessage: "\"composite\" is deprecated, use \"objective.composite\" instead.",
+		Validators:         []validator.List{listvalidator.SizeAtMost(1)},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"target": schema.Float64Attribute{

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -235,6 +235,41 @@ func TestAccSLOResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_deprecatedCompositeCardinality(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	model := getExampleSLOResource(t)
+	model.Name = e2etestutils.GenerateName()
+	config := newSLOResource(t, sloResourceTemplateModel{
+		ResourceName:     "test",
+		SLOResourceModel: model,
+	})
+	config, ok := strings.CutSuffix(config, "}\n")
+	require.True(t, ok)
+	config += `
+  composite {
+    target = 0.95
+  }
+
+  composite {
+    target = 0.90
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: config,
+			ExpectError: regexp.MustCompile(
+				`(?s)Error: Invalid Attribute Value.*Attribute composite list must contain at most 1 elements, got: 2`,
+			),
+			PlanOnly: true,
+		}},
+	})
+}
+
 func TestAccSLOResource_labelValidationErrors(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -250,10 +250,20 @@ func TestAccSLOResource_deprecatedCompositeCardinality(t *testing.T) {
 	config += `
   composite {
     target = 0.95
+
+    burn_rate_condition {
+      op    = "gt"
+      value = 2
+    }
   }
 
   composite {
     target = 0.90
+
+    burn_rate_condition {
+      op    = "gt"
+      value = 2
+    }
   }
 }
 `


### PR DESCRIPTION
## Motivation

The framework migration dropped the legacy maximum-one constraint from the deprecated top-level SLO `composite` block. Terraform could therefore accept multiple blocks even though conversion uses only the first one.

## Summary

- Enforced at most one deprecated top-level `composite` block.
- Documented the restored cardinality in the generated SLO resource reference.
- Added focused acceptance coverage for the framework plan diagnostic.

## Testing

The regression was reproduced with this configuration after supplying an existing service and metric source:

```hcl
variable "project" {
  type = string
}

variable "service" {
  type = string
}

variable "indicator_name" {
  type = string
}

variable "indicator_project" {
  type = string
}

resource "nobl9_slo" "repro" {
  name             = "example-slo"
  project          = var.project
  service          = var.service
  budgeting_method = "Occurrences"

  indicator {
    name    = var.indicator_name
    project = var.indicator_project
    kind    = "Direct"
  }

  objective {
    target = 0.99
    value  = 1
    op     = "lt"

    raw_metric {
      query {
        prometheus {
          promql = "up"
        }
      }
    }
  }

  composite {
    target = 0.95

    burn_rate_condition {
      op    = "gt"
      value = 2
    }
  }

  composite {
    target = 0.90

    burn_rate_condition {
      op    = "gt"
      value = 2
    }
  }

  time_window {
    count      = 1
    unit       = "Day"
    is_rolling = true
  }
}
```

Before this change, Terraform accepted both valid blocks without a diagnostic:

```text
Plan: 1 to add, 0 to change, 0 to destroy.
```

With this change, planning returns:

```text
Error: Invalid Attribute Value

Attribute composite list must contain at most 1 elements, got: 2
```

`TestAccSLOResource_deprecatedCompositeCardinality` covered the valid duplicate blocks and the local cardinality diagnostic.

## Release Notes

Updated Terraform planning to reject SLO resources with more than one deprecated top-level `composite` block.
