### PR TITLE
fix: validate composite aggregation

### DIFF
--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -1044,6 +1044,9 @@ func sloResourceCompositeV2ObjectiveBlock() schema.ListNestedBlock {
 						"Aggregation method for composite SLO. Valid values: %s.",
 						strings.Join(v1alphaSLO.ComponentAggregationMethodNames(), ","),
 					),
+					Validators: []validator.String{
+						stringvalidator.OneOf(v1alphaSLO.ComponentAggregationMethodNames()...),
+					},
 				},
 			},
 			Blocks: map[string]schema.Block{

--- a/internal/frameworkprovider/slo_resource_schema.go
+++ b/internal/frameworkprovider/slo_resource_schema.go
@@ -1045,7 +1045,10 @@ func sloResourceCompositeV2ObjectiveBlock() schema.ListNestedBlock {
 						strings.Join(v1alphaSLO.ComponentAggregationMethodNames(), ","),
 					),
 					Validators: []validator.String{
-						stringvalidator.OneOf(v1alphaSLO.ComponentAggregationMethodNames()...),
+						stringvalidator.OneOf(append(
+							[]string{""},
+							v1alphaSLO.ComponentAggregationMethodNames()...,
+						)...),
 					},
 				},
 			},

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -235,6 +235,33 @@ func TestAccSLOResource_planValidation(t *testing.T) {
 	})
 }
 
+func TestAccSLOResource_compositeAggregationValidation(t *testing.T) {
+	t.Parallel()
+	testAccSetup(t)
+
+	model := newSLOResourceConfigFromManifest(getCompositeSLOExample(t))
+	model.Name = e2etestutils.GenerateName()
+	model.Objectives = model.Objectives[:1]
+	model.Objectives[0].Composite[0].Aggregation = types.StringValue("invalid")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: newSLOResource(t, sloResourceTemplateModel{
+					ResourceName:     "test",
+					SLOResourceModel: *model,
+				}),
+				ExpectError: regexp.MustCompile(
+					`(?s)Invalid Attribute Value.*objective\[0\]\.composite\[0\]\.aggregation.*` +
+						`Reliability.*ErrorBudgetState.*got: "invalid"`,
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccSLOResource_labelValidationErrors(t *testing.T) {
 	t.Parallel()
 	testAccSetup(t)

--- a/internal/frameworkprovider/slo_resource_test.go
+++ b/internal/frameworkprovider/slo_resource_test.go
@@ -253,8 +253,8 @@ func TestAccSLOResource_compositeAggregationValidation(t *testing.T) {
 					SLOResourceModel: *model,
 				}),
 				ExpectError: regexp.MustCompile(
-					`(?s)Invalid Attribute Value.*objective\[0\]\.composite\[0\]\.aggregation.*` +
-						`Reliability.*ErrorBudgetState.*got: "invalid"`,
+					`(?s)Invalid Attribute Value Match.*objective\[0\]\.composite\[0\]\.aggregation.*` +
+						`must be one of: \[""\s+"Reliability"\s+"ErrorBudgetState"\], got: "invalid"`,
 				),
 				PlanOnly: true,
 			},
@@ -1228,6 +1228,31 @@ func TestAccSLOResource_custom(t *testing.T) {
 					}
 				model.Indicator = nil
 				return model
+			},
+		},
+		"composite with empty aggregation": {
+			sloResourceModelModifier: func(t *testing.T, model SLOResourceModel) SLOResourceModel {
+				slo := getCompositeSLOExample(t)
+				compositeModel := newSLOResourceConfigFromManifest(slo)
+				compositeModel.Objectives = compositeModel.Objectives[:1]
+				model.Objectives = compositeModel.Objectives
+				model.Objectives[0].Composite[0].Aggregation = types.StringValue("")
+				model.Objectives[0].Composite[0].Components[0].Objectives[0].CompositeObjective =
+					[]CompositeObjectiveSpecModel{
+						{
+							Project:     manifestSLOComponent1.GetProject(),
+							SLO:         manifestSLOComponent1.GetName(),
+							Objective:   manifestSLOComponent1.Spec.Objectives[0].Name,
+							Weight:      1,
+							WhenDelayed: v1alphaSLO.WhenDelayedCountAsGood.String(),
+						},
+					}
+				model.Indicator = nil
+				return model
+			},
+			sloManifestModifier: func(t *testing.T, slo v1alphaSLO.SLO) v1alphaSLO.SLO {
+				slo.Spec.Objectives[0].Composite.Aggregation = v1alphaSLO.ComponentAggregationMethodDefault
+				return slo
 			},
 		},
 	}


### PR DESCRIPTION
## Motivation

The framework-migrated SLO schema documented the supported composite aggregation methods but did not validate them. Terraform planning therefore accepted arbitrary strings that the manifest conversion could not parse.

## Summary

- Added validation for composite aggregation against the API-backed method enumeration.
- Preserved the released explicit-empty behavior.
- Added acceptance coverage for invalid and explicit-empty aggregation values.

## Testing

The regression was reproduced with this plan-only configuration:

```hcl
variable "project" {
  type = string
}

variable "service" {
  type = string
}

variable "component_slo" {
  type = string
}

variable "component_objective" {
  type = string
}

resource "nobl9_slo" "repro" {
  name             = "composite-aggregation-repro"
  project          = var.project
  service          = var.service
  budgeting_method = "Occurrences"

  objective {
    name   = "composite-objective"
    target = 0.99

    composite {
      max_delay   = "5m"
      aggregation = "invalid"

      components {
        objectives {
          composite_objective {
            project      = var.project
            slo          = var.component_slo
            objective    = var.component_objective
            weight       = 1
            when_delayed = "Ignore"
          }
        }
      }
    }
  }

  time_window {
    count      = 1
    unit       = "Day"
    is_rolling = true
  }
}
```

Before this change, Terraform accepted the invalid value without a diagnostic:

```text
Plan: 1 to add, 0 to change, 0 to destroy.
```

With this change, planning returns:

```text
Error: Invalid Attribute Value Match

Attribute objective[0].composite[0].aggregation value must be one of: [""
"Reliability" "ErrorBudgetState"], got: "invalid"
```

`TestAccSLOResource_compositeAggregationValidation` verified the exact invalid-value diagnostic. `TestAccSLOResource_custom/composite_with_empty_aggregation` verified that `aggregation = ""` still applies and reconciles to the API default.

## Release Notes

Terraform planning was updated to reject unsupported composite SLO aggregation values.
