### PR TITLE
fix: preserve Replay diagnostics with current SDK types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/nobl9/nobl9-go v0.135.0-rc1
+	github.com/nobl9/nobl9-go v0.135.0-rc3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.12.1
 	github.com/teambition/rrule-go v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,12 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nobl9/govy v0.26.0 h1:pjHXreO+3Rl+Uz6/rFX7L54zH4LW/SaTjb6YX3GQGs4=
 github.com/nobl9/govy v0.26.0/go.mod h1:fExiIzXORe0ktwg2bWasOAmCZtEFMQkR4PpgzhHcZSA=
-github.com/nobl9/nobl9-go v0.135.0-rc1 h1:/QkT+eMZ+mzw9B8XwyA+Y5vB/1akiWvipi1clx/bZtA=
-github.com/nobl9/nobl9-go v0.135.0-rc1/go.mod h1:R7tdHY7Audcsc84XEYK3jmmevOoUFlo44AgDtv7D54c=
+github.com/nobl9/nobl9-go v0.135.0-rc3 h1:tQGNTt8NwU7vV2q+mQP03afP40r88d/Lchs1mZEz9UE=
+github.com/nobl9/nobl9-go v0.135.0-rc3/go.mod h1:N9UxRbNPOShi3qnylVNjY39C2ZeGQRbBcdQnhaLKMow=
+github.com/nobl9/nobl9-go v0.135.0-rc3.0.20260907135500-23f1d0a2b164 h1:n67OCdm6x/P5NmeWite3fS0uPIdjck9LDWGRx2AZJi0=
+github.com/nobl9/nobl9-go v0.135.0-rc3.0.20260907135500-23f1d0a2b164/go.mod h1:N9UxRbNPOShi3qnylVNjY39C2ZeGQRbBcdQnhaLKMow=
+github.com/nobl9/nobl9-go v0.135.0-rc3.0.20260907183448-257cd86f148a h1:8jZEt1uUu2U5cLw/48BMvdx2NPWWVLev6jIFbJrFX8k=
+github.com/nobl9/nobl9-go v0.135.0-rc3.0.20260907183448-257cd86f148a/go.mod h1:N9UxRbNPOShi3qnylVNjY39C2ZeGQRbBcdQnhaLKMow=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/frameworkprovider/sdk_client.go
+++ b/internal/frameworkprovider/sdk_client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/nobl9/nobl9-go/sdk"
 	v1Objects "github.com/nobl9/nobl9-go/sdk/endpoints/objects/v1"
 	v2 "github.com/nobl9/nobl9-go/sdk/endpoints/objects/v2"
-	sdkModels "github.com/nobl9/nobl9-go/sdk/models"
+	replayV1 "github.com/nobl9/nobl9-go/sdk/endpoints/replay/v1"
 
 	"github.com/nobl9/terraform-provider-nobl9/internal/version"
 )
@@ -187,9 +187,8 @@ func (s sdkClient) GetSLO(ctx context.Context, name, project string) (v1alphaSLO
 
 // Replay runs historical data retrieval for the given SLO.
 //
-// TODO: Once https://github.com/nobl9/nobl9-go/pull/756 is merged,
-// we can remove this in favor of SDK-defined methods.
-func (s sdkClient) Replay(ctx context.Context, payload sdkModels.Replay) error {
+// Read the response body directly to preserve Replay availability diagnostics.
+func (s sdkClient) Replay(ctx context.Context, payload replayV1.RunRequest) error {
 	body := new(bytes.Buffer)
 	if err := json.NewEncoder(body).Encode(payload); err != nil {
 		return err
@@ -290,17 +289,17 @@ func setClientUserAgent(client *sdk.Client) {
 
 func replayUnavailabilityReasonExplanation(reason []byte, statusCode int) string {
 	strReason := strings.TrimSpace(string(reason))
-	switch strReason {
-	case sdkModels.ReplayIntegrationDoesNotSupportReplay:
+	switch replayV1.ReplayAvailabilityReason(strReason) {
+	case replayV1.ReplayIntegrationDoesNotSupportReplay:
 		return "The Data Source does not support Replay yet"
-	case sdkModels.ReplayAgentVersionDoesNotSupportReplay:
+	case replayV1.ReplayAgentVersionDoesNotSupportReplay:
 		return "Update your Agent version to the latest to use Replay for this Data Source."
-	case sdkModels.ReplayMaxHistoricalDataRetrievalTooLow:
+	case replayV1.ReplayMaxHistoricalDataRetrievalTooLow:
 		return "Value configured for spec.historicalDataRetrieval.maxDuration.value" +
 			" for the Data Source is lower than the duration you're trying to run Replay for."
-	case sdkModels.ReplayConcurrentReplayRunsLimitExhausted:
+	case replayV1.ReplayConcurrentReplayRunsLimitExhausted:
 		return "You've exceeded the limit of concurrent Replay runs. Wait until the current Replay(s) are done."
-	case sdkModels.ReplayUnknownAgentVersion:
+	case replayV1.ReplayUnknownAgentVersion:
 		return "Your Agent isn't connected to the Data Source. Deploy the Agent and run Replay once again."
 	case "single_query_not_supported":
 		return "Historical data retrieval for single-query ratio metrics is not supported"

--- a/internal/frameworkprovider/sdk_client_replay_test.go
+++ b/internal/frameworkprovider/sdk_client_replay_test.go
@@ -1,0 +1,73 @@
+package frameworkprovider
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/nobl9/nobl9-go/sdk"
+	replayV1 "github.com/nobl9/nobl9-go/sdk/endpoints/replay/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSDKClientReplay(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{name: "success", status: http.StatusOK},
+		{
+			name: "known availability reason", status: http.StatusConflict,
+			body:    " integration_does_not_support_replay\n",
+			wantErr: "The Data Source does not support Replay yet",
+		},
+		{
+			name: "unknown availability reason", status: http.StatusBadRequest,
+			body:    "additional restriction",
+			wantErr: "bad response (status: 400): additional restriction",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/api/timetravel", r.URL.Path)
+				assert.Equal(t, "example", r.Header.Get(sdk.HeaderProject))
+				body, err := io.ReadAll(r.Body)
+				if assert.NoError(t, err) {
+					assert.JSONEq(t, `{
+						"project":"example",
+						"slo":"application-score",
+						"duration":{"unit":"Minute","value":60}
+					}`, string(body))
+				}
+				w.WriteHeader(tc.status)
+				_, err = io.WriteString(w, tc.body)
+				assert.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+			apiURL, err := url.Parse(server.URL + "/api")
+			require.NoError(t, err)
+			client, err := sdk.NewClient(&sdk.Config{
+				URL: apiURL, DisableOkta: true, Organization: "example", Timeout: time.Second,
+			})
+			require.NoError(t, err)
+			err = (sdkClient{client: client}).Replay(t.Context(), replayV1.RunRequest{
+				Project: "example", SLO: "application-score",
+				Duration: replayV1.Duration{Unit: replayV1.DurationUnitMinute, Value: 60},
+			})
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/frameworkprovider/slo_resource.go
+++ b/internal/frameworkprovider/slo_resource.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/nobl9/nobl9-go/manifest"
 	v1alphaSLO "github.com/nobl9/nobl9-go/manifest/v1alpha/slo"
-	sdkModels "github.com/nobl9/nobl9-go/sdk/models"
+	replayV1 "github.com/nobl9/nobl9-go/sdk/endpoints/replay/v1"
 )
 
 // Ensure [SLOResource] fully satisfies framework interfaces.
@@ -380,11 +380,11 @@ func (s *SLOResource) runReplay(ctx context.Context, config tfsdk.Config, model 
 	replayFromTS, _ := time.Parse(time.RFC3339, model.RetrieveHistoricalDataFrom.ValueString())
 	const startOffsetMinutes = 5
 	windowDuration := time.Since(replayFromTS)
-	payload := sdkModels.Replay{
+	payload := replayV1.RunRequest{
 		Project: model.Project,
-		Slo:     model.Name,
-		Duration: sdkModels.ReplayDuration{
-			Unit:  sdkModels.DurationUnitMinute,
+		SLO:     model.Name,
+		Duration: replayV1.Duration{
+			Unit:  replayV1.DurationUnitMinute,
 			Value: startOffsetMinutes + int(windowDuration.Minutes()),
 		},
 	}


### PR DESCRIPTION
## Release Notes



## Motivation

The provider still uses Replay models removed from newer SDK releases. Update to the current Replay request types while preserving actionable availability errors.

## Summary

- Use the published SDK release and Replay v1 request and reason types.
- Preserve the existing Replay payload, project header, and availability diagnostics.

## Related Changes

[Zscaler SDK support](https://github.com/nobl9/nobl9-go/pull/989).

## Testing

- [ ] Run historical retrieval for an existing SLO and confirm that the request still starts Replay.
- [ ] Request unavailable Replay and verify that the reason remains actionable.
